### PR TITLE
Pin pyopenssl to 21.0.0

### DIFF
--- a/kowalski/requirements_ingester.txt
+++ b/kowalski/requirements_ingester.txt
@@ -20,6 +20,7 @@ protobuf==3.20.*
 pyarrow==5.0.0
 pyjwt==2.4.0
 pymongo==3.12.0
+pyopenssl==21.0.0
 pytest==6.2.5
 pytz==2021.1
 pyyaml==5.4.1


### PR DESCRIPTION
Otherwise `pymongo==3.12.0` does not work with `python==3.7.9`