### PR TITLE
Modify pip command to ensure dependencies are resolved

### DIFF
--- a/api.Dockerfile
+++ b/api.Dockerfile
@@ -16,7 +16,7 @@ COPY ["config.yaml", "version.txt", "kowalski/generate_supervisord_conf.py",\
 WORKDIR /app
 
 # install python libs and generate supervisord config file
-RUN pip install -r /app/requirements_api.txt --no-cache-dir && \
+RUN pip install -r /app/requirements_api.txt --no-cache-dir --use-feature=2020-resolver && \
     python generate_supervisord_conf.py api
 
 # run container

--- a/ingester.Dockerfile
+++ b/ingester.Dockerfile
@@ -79,7 +79,7 @@ COPY ["config.yaml", "version.txt", "kowalski/generate_supervisord_conf.py", "ko
 WORKDIR /app
 
 # install python libs and generate supervisord config file
-RUN pip install -r /app/requirements_ingester.txt --no-cache-dir && \
+RUN pip install -r /app/requirements_ingester.txt --no-cache-dir --use-feature=2020-resolver && \
     python generate_supervisord_conf.py ingester
 
 # run container


### PR DESCRIPTION
pip >= 20.3 cannot resolve the dependencies required by kowalski. 
This command is the recommended way to ensure dependencies get resolved. 