### PR TITLE
Deal with redshift=0 entries in CLU

### DIFF
--- a/kowalski/alert_broker.py
+++ b/kowalski/alert_broker.py
@@ -857,12 +857,15 @@ class AlertWorker:
                 alpha1, delta01 = galaxy["ra"], galaxy["dec"]
 
                 redshift = galaxy["z"]
-                # By default, set the cross-match radius to 30 kpc at the redshift of the host galaxy
-                cm_radius = 30.0 * (0.05 / redshift) / 3600
+
                 if redshift < 0.01:
                     # for nearby galaxies and galaxies with negative redshifts, do a 5 arc-minute cross-match
                     # (cross-match radius would otherwise get un-physically large for nearby galaxies)
                     cm_radius = 300.0 / 3600
+
+                else:
+                    # For distant galaxies, set the cross-match radius to 30 kpc at the redshift of the host galaxy
+                    cm_radius = 30.0 * (0.05 / redshift) / 3600
 
                 in_galaxy = in_ellipse(ra, dec, alpha1, delta01, cm_radius, 1, 0)
 


### PR DESCRIPTION
The CLU-xmatch on kowalski has two steps within a try-except clause : 
1. Perform a coarse cone search to get a shortlist of possible associated galaxies
2. Run an ellipse search on the shortlisted galaxies to find the true associations.

Step 1 involves a division by redshift. Some entries in the CLU catalog have `redshift=0`, which raise an exception. Consequently, step 2 is not run for alerts where such galaxies happen to be part of the shortlist. I have identified some alerts that fail the CLU filter for this reason, when they should have clearly passed it (eg. https://fritz.science/source/ZTF22abbcnay and https://fritz.science/source/ZTF22abmzedb). 

This short PR refactors the xmatch function slightly to resolve this issue. It makes sure that the division by redshift does not happen for galaxies with redshift=0.
 