### PR TITLE
Bump tensorflow, make protobuf more flexible

### DIFF
--- a/kowalski/requirements_ingester.txt
+++ b/kowalski/requirements_ingester.txt
@@ -16,7 +16,7 @@ motor==2.5.1
 numba==0.55.2
 numpy==1.21.6
 pandas==1.3.2
-protobuf==3.20.*
+protobuf >=3.9.2, <3.20
 pyarrow==5.0.0
 pyjwt==2.4.0
 pymongo==3.12.0
@@ -28,6 +28,6 @@ requests==2.25.1
 slack_sdk==3.10.1
 supervisor==4.2.2
 tables==3.6.1
-tensorflow==2.7.2
+tensorflow==2.9.3
 tqdm==4.62.2
 uvloop==0.16.0


### PR DESCRIPTION
With a recent fix in tensorflow (https://github.com/advisories/GHSA-cg88-rpvp-cjv5), it would be good to switch to `tensorflow==2.9.3` (#181) . 

This PR 
1. Bumps tensorflow to v2.9.3
2. Matches the constraints of protobuf to those of [tensorflowv2.9.3](https://github.com/tensorflow/tensorflow/blob/a5ed5f39b675a1c6f315e0caf3ad4b38478fa571/tensorflow/tools/pip_package/setup.py#L97), resolving dependency issues arising from the tensorflow bump.