### PR TITLE
Update pyOpenSSL to latest version

### DIFF
--- a/kowalski/requirements_ingester.txt
+++ b/kowalski/requirements_ingester.txt
@@ -3,7 +3,7 @@ astropy==4.3.1
 bcrypt==3.2.0
 beautifulsoup4==4.10.0
 confluent_kafka==1.7.0
-cryptography==3.4.8
+cryptography==39.0.1
 dask==2021.10.0
 distributed==2021.10.0
 fastavro==1.4.4
@@ -20,7 +20,7 @@ protobuf >=3.9.2, <3.20
 pyarrow==5.0.0
 pyjwt==2.4.0
 pymongo==3.12.0
-pyopenssl==21.0.0
+pyopenssl==23.0.0
 pytest==6.2.5
 pytz==2021.1
 pyyaml==5.4.1


### PR DESCRIPTION
This PR updates pyopenssl to the latest version 23.0.0 so that it is compatible with the latest version of cryptography v39.0.1