### PR TITLE
WIP: Achieve arm64 compatibility

### DIFF
--- a/api.Dockerfile
+++ b/api.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.8
 #FROM python:3.7-slim
 
 RUN apt-get update
@@ -16,7 +16,8 @@ COPY ["config.yaml", "version.txt", "kowalski/generate_supervisord_conf.py",\
 WORKDIR /app
 
 # install python libs and generate supervisord config file
-RUN pip install -r /app/requirements_api.txt --no-cache-dir --use-feature=2020-resolver && \
+RUN pip install --upgrade pip
+RUN pip install -r /app/requirements_api.txt --no-cache-dir && \
     python generate_supervisord_conf.py api
 
 # run container

--- a/ingester.Dockerfile
+++ b/ingester.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.8
 
 ARG kafka_version=2.13-2.5.0
 ARG braai_version=d6_m9
@@ -79,7 +79,7 @@ COPY ["config.yaml", "version.txt", "kowalski/generate_supervisord_conf.py", "ko
 WORKDIR /app
 
 # install python libs and generate supervisord config file
-RUN pip install -r /app/requirements_ingester.txt --no-cache-dir --use-feature=2020-resolver && \
+RUN pip install -r /app/requirements_ingester.txt --no-cache-dir && \
     python generate_supervisord_conf.py ingester
 
 # run container

--- a/ingester.Dockerfile
+++ b/ingester.Dockerfile
@@ -79,6 +79,7 @@ COPY ["config.yaml", "version.txt", "kowalski/generate_supervisord_conf.py", "ko
 WORKDIR /app
 
 # install python libs and generate supervisord config file
+RUN pip install --upgrade pip
 RUN pip install -r /app/requirements_ingester.txt --no-cache-dir && \
     python generate_supervisord_conf.py ingester
 

--- a/kowalski/requirements_api.txt
+++ b/kowalski/requirements_api.txt
@@ -1,7 +1,7 @@
 aiofiles>=0.6.0
 aiohttp>=3.7.3
 aiohttp-swagger3==0.5.1
-astropy>=4.2
+astropy==5.2.1
 bcrypt>=3.2.0
 cryptography>=3.2.1
 gunicorn==20.0.4

--- a/kowalski/requirements_ingester.txt
+++ b/kowalski/requirements_ingester.txt
@@ -1,5 +1,5 @@
 aiohttp==3.7.4
-astropy==4.3.1
+astropy==5.2.1
 bcrypt==3.2.0
 beautifulsoup4==4.10.0
 confluent_kafka==1.7.0
@@ -10,7 +10,7 @@ fastavro==1.4.4
 fire==0.4.0
 gsutil==4.67
 gunicorn==20.1.0
-h5py==3.1.0
+h5py==3.8.0
 matplotlib==3.4.3
 motor==2.5.1
 numba==0.55.2
@@ -27,7 +27,7 @@ pyyaml==5.4.1
 requests==2.25.1
 slack_sdk==3.10.1
 supervisor==4.2.2
-tables==3.6.1
-tensorflow==2.9.3
+tables==3.7.0
+tensorflow==2.11.0
 tqdm==4.62.2
 uvloop==0.16.0


### PR DESCRIPTION
This PR lists WIP changes to Python and other software versions needed to get Kowalski running on an M1 Mac. We will still need to work out a way to install tensorflow successfully, perhaps using the technique described [here](https://github.com/ZwickyTransientFacility/scope/blob/main/doc/developer.md).