### PR TITLE
more generous retries in the test_ingester_ztf

### DIFF
--- a/tests/test_ingester_pgir.py
+++ b/tests/test_ingester_pgir.py
@@ -149,7 +149,7 @@ class TestIngester:
                 print(
                     "Found an unexpected amount of alert/aux data: "
                     f"({n_alerts}/{n_alerts_aux}, expecting 17/15). "
-                    "Retrying in 30 seconds..."
+                    "Retrying in 15 seconds..."
                 )
                 time.sleep(15)
                 continue

--- a/tests/test_ingester_turbo.py
+++ b/tests/test_ingester_turbo.py
@@ -138,7 +138,7 @@ class TestIngester:
                 print(
                     "Found an unexpected amount of alert/aux data: "
                     f"({n_alerts}/{n_alerts_aux}, expecting 11/11). "
-                    "Retrying in 30 seconds..."
+                    "Retrying in 15 seconds..."
                 )
                 time.sleep(15)
                 continue

--- a/tests/test_ingester_wntr.py
+++ b/tests/test_ingester_wntr.py
@@ -141,7 +141,7 @@ class TestIngester:
                 print(
                     "Found an unexpected amount of alert/aux data: "
                     f"({n_alerts}/{n_alerts_aux}, expecting 5/4). "
-                    "Retrying in 30 seconds..."
+                    "Retrying in 15 seconds..."
                 )
                 time.sleep(15)
                 continue

--- a/tests/test_ingester_ztf.py
+++ b/tests/test_ingester_ztf.py
@@ -399,7 +399,7 @@ class TestIngester:
             log("Digested and ingested: all done!")
 
         log("Checking the ZTF alert collection states")
-        num_retries = 7
+        num_retries = 13
         # alert processing takes time, which depends on the available resources
         # so allow some additional time for the processing to finish
         for i in range(num_retries):
@@ -417,7 +417,7 @@ class TestIngester:
                 print(
                     "Found an unexpected amount of alert/aux data: "
                     f"({n_alerts}/{n_alerts_aux}, expecting 313/145). "
-                    "Retrying in 30 seconds..."
+                    "Retrying in 15 seconds..."
                 )
                 time.sleep(15)
                 continue


### PR DESCRIPTION
Turns out I've been a little bit too optimistic in the TURBO PR when I reduced the number of retries in all the ingester tests, especially considering how many alerts the ZTF one's are ingesting. 

In this PR (which might be followed by another if this isn't enough), we try to slowly bring that number back up until we reach a reasonable value, where valid tests can pass, but tests with errors do not make us wait 10 minutes before we can restart them and know about their failure.