### PR TITLE
GET methods of ZTF endpoint: Pass JSONs and not Query Params

### DIFF
--- a/kowalski/api.py
+++ b/kowalski/api.py
@@ -2170,10 +2170,10 @@ class ZTFTriggerHandler(Handler):
                   type: object
         """
 
-        _data = await request.json()
+        # _data = await request.json()
 
         # validate
-        ZTFTriggerGet(**_data)
+        # ZTFTriggerGet(**_data)
         if self.test:
             return self.success(message="submitted", data=[{"queue_name": "test"}])
 
@@ -2190,7 +2190,7 @@ class ZTFTriggerHandler(Handler):
         server.start()
         url = f"http://{server.local_bind_address[0]}:{server.local_bind_address[1]}/queues"
         async with ClientSession() as client_session:
-            async with client_session.get(url, params=_data, timeout=10) as response:
+            async with client_session.get(url, json={}, timeout=10) as response:
                 response_json = await response.json()
         server.stop()
 
@@ -2399,10 +2399,10 @@ class ZTFMMATriggerHandler(Handler):
                   type: object
         """
 
-        _data = await request.json()
+        # _data = await request.json()
 
         # validate
-        ZTFMMATriggerGet(**_data)
+        # ZTFMMATriggerGet(**_data)
 
         if self.test:
             return self.success(message="submitted", data=[{"trigger_name": "test"}])
@@ -2420,7 +2420,7 @@ class ZTFMMATriggerHandler(Handler):
         server.start()
         url = f"http://{server.local_bind_address[0]}:{server.local_bind_address[1]}/mma_skymaps"
         async with ClientSession() as client_session:
-            async with client_session.get(url, params=_data, timeout=10) as response:
+            async with client_session.get(url, json={}, timeout=10) as response:
                 response_json = await response.json()
         server.stop()
 

--- a/kowalski/api.py
+++ b/kowalski/api.py
@@ -2170,10 +2170,10 @@ class ZTFTriggerHandler(Handler):
                   type: object
         """
 
-        # _data = await request.json()
+        _data = await request.json()
 
         # validate
-        # ZTFTriggerGet(**_data)
+        ZTFTriggerGet(**_data)
         if self.test:
             return self.success(message="submitted", data=[{"queue_name": "test"}])
 
@@ -2190,7 +2190,7 @@ class ZTFTriggerHandler(Handler):
         server.start()
         url = f"http://{server.local_bind_address[0]}:{server.local_bind_address[1]}/queues"
         async with ClientSession() as client_session:
-            async with client_session.get(url, json={}, timeout=10) as response:
+            async with client_session.get(url, json=_data, timeout=10) as response:
                 response_json = await response.json()
         server.stop()
 
@@ -2399,10 +2399,10 @@ class ZTFMMATriggerHandler(Handler):
                   type: object
         """
 
-        # _data = await request.json()
+        _data = await request.json()
 
         # validate
-        # ZTFMMATriggerGet(**_data)
+        ZTFMMATriggerGet(**_data)
 
         if self.test:
             return self.success(message="submitted", data=[{"trigger_name": "test"}])
@@ -2420,7 +2420,7 @@ class ZTFMMATriggerHandler(Handler):
         server.start()
         url = f"http://{server.local_bind_address[0]}:{server.local_bind_address[1]}/mma_skymaps"
         async with ClientSession() as client_session:
-            async with client_session.get(url, json={}, timeout=10) as response:
+            async with client_session.get(url, json=_data, timeout=10) as response:
                 response_json = await response.json()
         server.stop()
 


### PR DESCRIPTION
Right now we can't get the queues from ZTF through Kowalski. In a recent PR, we added verification of the content of the GET requests sent by Fritz, and we pass said content to the ZTF endpoints (where before, we would hit the endpoint with no params or json). This is useful to hit their GET endpoints while specifying a specific trigger or queue name, and not just get the while list.

However this creates issues for now, and while we get an answer from the ZTF side, it is best to comment the validation so that the queries can work on the Fritz side.