### PR TITLE
ZTF Matchfiles ingestion: track failures

### DIFF
--- a/kowalski/log.py
+++ b/kowalski/log.py
@@ -2,6 +2,9 @@ import datetime
 import os
 
 LOG_DIR = "./logs"
+USING_DOCKER = os.environ.get("USING_DOCKER", False)
+if USING_DOCKER:
+    LOG_DIR = "/data/logs"
 
 
 def time_stamp():

--- a/kowalski/log.py
+++ b/kowalski/log.py
@@ -20,7 +20,7 @@ def log(message):
     print(f"{timestamp}: {message}")
 
     if not os.path.isdir(LOG_DIR):
-        os.mkdir(LOG_DIR)
+        os.makedirs(LOG_DIR, exist_ok=True)
 
     date = timestamp.split("_")[0]
     with open(os.path.join(LOG_DIR, f"kowalski_{date}.log"), "a") as logfile:


### PR DESCRIPTION
We ran into several issues while ingestion DR16 on melman recently. DR17 was released yesterday, and we need to make sure the existing script allows for easy reruns.

After reading the current script carefully, we can see that the `_id` of every mongo document ingested is unique, and made of a `baseid` (unique, made of field, readout and filter) + matchid unique to each entries of the matchfiles.

Thanks to that, we do not need to flush the database before reingesting, as the behavior of MongoDB should be to ignore existing documents.

Therefore, we just need some extra tools to keep track of which files failed ingesting, so that we can retry ingesting only these files. If one uses `rm` then anyway only failed files will be left. However this allows reingestion when not using this argument, as well as keeping track of the error messages for each failed ingestion. Essential to figure out if anything needs to be modified to get around that failure.

Also, we add some extra arguments to the fetching script, which allow us to only download missing (useful if the download was interrupted), or to only fetch the csv without also downloading the files (useful for debug or when we want to decouple that process. That might be needed if we want to remove some already ingested files from the csv to only redownload the ones we need).

TODO: add a method to verify the download of files. If a file is corrupted, we delete it. That way, we can restart the script using the argument to only download missing files. Unclear how this will be done, as a checksum isn't provided. pytables format can contain some sort of checksum, and I believe that I've seen failures in production mentioning that the file didn't end as expected. If that's how it works, we could simply open and close the file. If opening it failed, then we can remove the corrupted file and retry the download.