### PR TITLE
penquins 2.3.2

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -1226,7 +1226,7 @@ kowalski:
   misc:
     # working stand-alone or in conjunction with a SkyPortal instance?
     broker: False
-    supported_penquins_versions: ["2.0.0", "2.0.1", "2.0.2", "2.1.0", "2.1.1", "2.2.0", "2.2.1", "2.3.1"]
+    supported_penquins_versions: ["2.0.0", "2.0.1", "2.0.2", "2.1.0", "2.1.1", "2.2.0", "2.2.1", "2.3.1", "2.3.2", "2.3.3"]
     query_expiration_interval: 5
     max_time_ms: 300000
     max_retries: 100


### PR DESCRIPTION
This PR adds penquins 2.3.2 (and 2.3.3 in advance) to the default config.