### PR TITLE
MongoDB: Cache size limit

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,8 +13,8 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
       - name: Install dependencies

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,8 +13,8 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
       - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ models/
 logs/
 conf/*
 !conf/*.template
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -98,19 +98,22 @@ test: setup_all init_models init_kafka
 test_macos: setup_all_macos init_models init_kafka
 	$(PYTHON) kowalski/tools/tests.py
 
-docker_up: setup
+docker_setup: setup
+	$(PYTHON) kowalski/tools/docker.py setup $(FLAGS)
+
+docker_up: docker_setup
 	$(PYTHON) kowalski/tools/docker.py up $(FLAGS)
 
-docker_down: setup
+docker_down: docker_setup
 	$(PYTHON) kowalski/tools/docker.py down $(FLAGS)
 
-docker_build: setup
+docker_build: docker_setup
 	$(PYTHON) kowalski/tools/docker.py build $(FLAGS)
 
-docker_test: setup
+docker_test: docker_setup
 	$(PYTHON) kowalski/tools/tests.py --use_docker
 
-docker_seed : setup
+docker_seed : docker_setup
 	$(PYTHON) kowalski/tools/docker.py seed $(FLAGS)
 
 log: ## Monitor log files for all services.

--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -42,6 +42,7 @@ kowalski:
 
   database:
     max_pool_size: 200
+    max_wired_tiger_cache: 20% # in GB or % of available RAM, e.g. 50% or 10GB. If no unit is specified, GB is assumed
     host: "localhost"
     port: 27017 # if not null, must be same as in entrypoint of mongo container
     replica_set: null

--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -42,7 +42,7 @@ kowalski:
 
   database:
     max_pool_size: 200
-    max_wired_tiger_cache: 20% # in GB or % of available RAM, e.g. 50% or 10GB. If no unit is specified, GB is assumed
+    max_wired_tiger_cache: # in GB or % of available RAM, e.g. 50% or 10GB. If no unit is specified, GB is assumed
     host: "localhost"
     port: 27017 # if not null, must be same as in entrypoint of mongo container
     replica_set: null

--- a/kowalski/alert_brokers/alert_broker.py
+++ b/kowalski/alert_brokers/alert_broker.py
@@ -873,7 +873,7 @@ class AlertWorker:
 
             """ catalogs """
             matches = []
-            cross_match_config = config["database"]["xmatch"][self.instrument]
+            cross_match_config = config["database"]["xmatch"].get(self.instrument, {})
             for catalog in cross_match_config:
                 try:
                     # if the catalog has "distance", "ra", "dec" in its config, then it is a catalog with distance


### PR DESCRIPTION
This PR makes it possible to set a limit other than the default 50% (of total RAM of the machine) used by MongoDB's WiredTiger engine which takes care of the caching, especially for READ operations.

That should help not use all the RAM of the machine in prod, and make the whole system more stable.