### PR TITLE
Docker commands: make sure to load docker config

### DIFF
--- a/kowalski/tools/docker.py
+++ b/kowalski/tools/docker.py
@@ -169,7 +169,7 @@ class DockerKowalski:
     @classmethod
     def setup(cls):
         # load config.yaml config
-        config = load_config(["config.yaml"])["kowalski"]
+        config = load_config(["config.yaml", "docker.yaml"])["kowalski"]
         # look for the max_wired_tiger_cache key in config.yaml in the database section
         max_wired_tiger_cache = config["database"].get("max_wired_tiger_cache", None)
 
@@ -264,7 +264,7 @@ class DockerKowalski:
         command = ["docker-compose", "-f", docker_config, "build"]
 
         # load config
-        config = load_config(["config.yaml"])["kowalski"]
+        config = load_config(["config.yaml", "docker.yaml"])["kowalski"]
 
         # get git version:
         git_hash_date = get_git_hash_date()
@@ -298,7 +298,7 @@ class DockerKowalski:
         print("Ingesting catalog dumps into a running Kowalski instance")
 
         # load config
-        config = load_config(["config.yaml"])["kowalski"]
+        config = load_config(["config.yaml", "docker.yaml"])["kowalski"]
 
         command = [
             "docker",


### PR DESCRIPTION
This makes sure that we load the docker config on top of the normal config when running any docker related commands. It doesn't have a big impact at all to not use it, except for the seed commands where it might not have the right DB credentials, and the wiredTigerCacheSizeGB that won't be taken into account if it is only in the docker config and not the normal one.