### PR TITLE
ZTF Matchfiles (DR) ingestion - Little more safety

### DIFF
--- a/kowalski/ingesters/ingest_ztf_matchfiles.py
+++ b/kowalski/ingesters/ingest_ztf_matchfiles.py
@@ -313,6 +313,7 @@ def process_file(argument_list: Sequence):
                                     if count == len(docs_sources):
                                         break
                                     n_retries += 1
+                                    time.sleep(15)
                                 if n_retries == 5:
                                     log(
                                         f"Failed to ingest batch {batch_num} fully after {n_retries} retries"
@@ -337,9 +338,26 @@ def process_file(argument_list: Sequence):
                 # In case mongo crashed and disconnected, docs will accumulate in documents
                 # keep on trying to insert them until successful
                 if not dry_run:
-                    mongo.insert_many(
-                        collection=collections["sources"], documents=docs_sources
-                    )
+                    n_retries = 0
+                    while n_retries < 5:
+                        mongo.insert_many(
+                            collection=collections["sources"], documents=docs_sources
+                        )
+                        ids = [doc["_id"] for doc in docs_sources]
+                        count = mongo.db[collections["sources"]].count_documents(
+                            {"_id": {"$in": ids}}
+                        )
+                        if count == len(docs_sources):
+                            break
+                        n_retries += 1
+                        time.sleep(15)
+                    if n_retries == 5:
+                        log(
+                            f"Failed to ingest batch {batch_num} fully after {n_retries} retries"
+                        )
+                        raise Exception(
+                            f"Failed to ingest batch {batch_num} fully after {n_retries} retries"
+                        )
                     # flush:
                     docs_sources = []
 

--- a/kowalski/tools/fetch_ztf_matchfiles.py
+++ b/kowalski/tools/fetch_ztf_matchfiles.py
@@ -104,7 +104,7 @@ def fetch_url(argument_list: Sequence):
                 if path.exists():
                     subprocess.run(["rm", "-f", str(path)])
                 n_retries += 1
-                time.sleep(15)
+                time.sleep(10)
                 continue
 
         if checksum is not None:
@@ -118,6 +118,7 @@ def fetch_url(argument_list: Sequence):
                 log(f"Checksum mismatch for {url}, redownloading")
                 subprocess.run(["rm", "-f", str(path)])
                 n_retries += 1
+                time.sleep(10)
                 continue
         else:
             # if we don't have a checksum, try to open the file with pytables to make sure it's not corrupted
@@ -128,6 +129,7 @@ def fetch_url(argument_list: Sequence):
                 log(f"Exception while opening {path}: {e}, redownloading")
                 subprocess.run(["rm", "-f", str(path)])
                 n_retries += 1
+                time.sleep(10)
                 continue
 
         break


### PR DESCRIPTION
This PR adds:
- Possibility to provide checksums, used to verify the downloaded files.
- If not provided, will now at least try to open and close the files with pytables to see if they are corrupted
- When ingesting matchfiles, after each batch, now queries the DB to verify that all the documents have been ingested. If not, retries a few times.

Number 3 needs to be tested, so the GA and production are the best way to verify that this works. In a previous PR we also added a try/except that wraps the whole ingestion of a file, and logs to a csv like format all the files which ingestion has failed, why it failed, and makes sure not to delete them. Then we can reference that csv when rerunning the ingestion to only try and reingest the failed files.