### PR TITLE
Mongo class: close method

### DIFF
--- a/kowalski/utils.py
+++ b/kowalski/utils.py
@@ -428,6 +428,14 @@ class Mongo:
                 )
                 traceback.print_exc()
 
+    def close(self):
+        try:
+            self.client.close()
+            return True
+        except Exception as e:
+            log(f"Error closing connection: {str(e)}")
+            return False
+
 
 def radec_str2rad(_ra_str, _dec_str):
     """


### PR DESCRIPTION
This PR adds a close method to the mongo db class, missing so far but useful for some scripts