### PR TITLE
WIP - Additional filtering to trigger automatic follow-up

### DIFF
--- a/kowalski/alert_brokers/alert_broker.py
+++ b/kowalski/alert_brokers/alert_broker.py
@@ -1386,11 +1386,10 @@ class AlertWorker:
         if self.verbose > 1:
             log(alert_thin)
 
-        not_saved_group_ids = (
-            []
-        )  # those are the groups to which the source ended up not being saved
+        # those are the groups to which the source ended up not being saved
         # because the filter's autosave specified to cancel the autosave if the source is already
         # save to certain groups
+        not_saved_group_ids = []
         with timer(
             f"Saving {alert['objectId']} {alert['candid']} as a Source on SkyPortal",
             self.verbose > 1,
@@ -1401,8 +1400,11 @@ class AlertWorker:
                     log(
                         f"Saved {alert['objectId']} {alert['candid']} as a Source on SkyPortal"
                     )
-                    saved_to_groups = response.json()["data"].get("saved_to_groups", [])
-                    if saved_to_groups is None or len(saved_to_groups) == 0:
+                    print(response.json())
+                    saved_to_groups = response.json()["data"].get(
+                        "saved_to_groups", None
+                    )
+                    if saved_to_groups is None:
                         not_saved_group_ids = (
                             []
                         )  # all groups failed to save, or not specified

--- a/kowalski/alert_brokers/alert_broker.py
+++ b/kowalski/alert_brokers/alert_broker.py
@@ -1283,11 +1283,11 @@ class AlertWorker:
 
                         if len(auto_followup_filtered_data) == 1:
                             priority = auto_followup_filter["priority"](
-                                alert, auto_followup_filtered_data[0]
+                                alert, alert_history, auto_followup_filtered_data[0]
                             )
                             comment = auto_followup_filter.get("comment", None)
                             if comment is not None:
-                                comment += f" (priority: {priority})"
+                                comment += f" (priority: {str(priority)})"
                             passed_filter["auto_followup"] = {
                                 "allocation_id": _filter["auto_followup"][
                                     "allocation_id"

--- a/kowalski/alert_brokers/alert_broker.py
+++ b/kowalski/alert_brokers/alert_broker.py
@@ -1170,6 +1170,7 @@ class AlertWorker:
                         "data": filtered_data[0],
                     }
 
+                    autosaved = False
                     # AUTOSAVE
                     if isinstance(_filter.get("autosave", False), bool):
                         passed_filter["autosave"] = _filter.get("autosave", False)
@@ -1209,8 +1210,13 @@ class AlertWorker:
                     else:
                         passed_filter["autosave"] = False
 
+                    if passed_filter.get("autosave", None) not in [False, None]:
+                        autosaved = True
+
                     # AUTO FOLLOWUP
-                    if _filter.get("auto_followup", {}).get("active", False):
+                    if autosaved is True and _filter.get("auto_followup", {}).get(
+                        "active", False
+                    ):
                         auto_followup_filter = deepcopy(_filter["auto_followup"])
 
                         # validate non-optional keys

--- a/kowalski/alert_brokers/alert_broker.py
+++ b/kowalski/alert_brokers/alert_broker.py
@@ -1734,10 +1734,16 @@ class AlertWorker:
             ):
                 response = self.api_skyportal(
                     "GET",
-                    f"/api/followup_request?sourceID={alert['objectId']}&status=submitted",
+                    f"/api/followup_request?sourceID={alert['objectId']}",
                 )
             if response.json()["status"] == "success":
                 existing_requests = response.json()["data"].get("followup_requests", [])
+                # only keep the completed and submitted requests
+                existing_requests = [
+                    r
+                    for r in existing_requests
+                    if r["status"] in ["completed", "submitted"]
+                ]
             else:
                 log(f"Failed to get followup requests for {alert['objectId']}")
                 existing_requests = []

--- a/kowalski/alert_brokers/alert_broker.py
+++ b/kowalski/alert_brokers/alert_broker.py
@@ -1269,6 +1269,19 @@ class AlertWorker:
                                     auto_followup_filter[
                                         "priority"
                                     ] = lambda alert, alert_history, data: 5
+                        elif (
+                            auto_followup_filter.get("payload", {}).get(
+                                "priority", None
+                            )
+                            is not None
+                        ):
+                            auto_followup_filter[
+                                "priority"
+                            ] = lambda alert, alert_history, data: auto_followup_filter[
+                                "payload"
+                            ][
+                                "priority"
+                            ]
                         else:
                             auto_followup_filter[
                                 "priority"
@@ -1306,7 +1319,7 @@ class AlertWorker:
                                     ],
                                     "target_group_ids": [_filter["group_id"]],
                                     "payload": {
-                                        **_filter["auto_followup"]["payload"],
+                                        **_filter["auto_followup"].get("payload", {}),
                                         "priority": priority,
                                         "start_date": datetime.datetime.utcnow().strftime(
                                             "%Y-%m-%dT%H:%M:%S.%f"
@@ -1548,7 +1561,11 @@ class AlertWorker:
                 f"Making {istrument_type} thumbnail for {alert['objectId']} {alert['candid']}",
                 self.verbose > 1,
             ):
-                thumb = self.make_thumbnail(alert, ttype, istrument_type)
+                try:
+                    thumb = self.make_thumbnail(alert, ttype, istrument_type)
+                except Exception:
+                    thumb = None
+                    continue
 
             with timer(
                 f"Posting {istrument_type} thumbnail for {alert['objectId']} {alert['candid']} to SkyPortal",

--- a/kowalski/alert_brokers/alert_broker.py
+++ b/kowalski/alert_brokers/alert_broker.py
@@ -1563,7 +1563,10 @@ class AlertWorker:
             ):
                 try:
                     thumb = self.make_thumbnail(alert, ttype, istrument_type)
-                except Exception:
+                except Exception as e:
+                    log(
+                        f"Failed to make {istrument_type} thumbnail for {alert['objectId']} {alert['candid']}: {e}"
+                    )
                     thumb = None
                     continue
 

--- a/kowalski/alert_brokers/alert_broker_pgir.py
+++ b/kowalski/alert_brokers/alert_broker_pgir.py
@@ -301,6 +301,25 @@ class PGIRAlertWorker(AlertWorker, ABC):
                     active_filter["fv"]["pipeline"]
                 )
 
+                # if autosave is a dict with a pipeline key, also add the upstream pipeline to it:
+                if (
+                    isinstance(active_filter.get("autosave", None), dict)
+                    and active_filter.get("autosave", {}).get("pipeline", None)
+                    is not None
+                ):
+                    active_filter["autosave"]["pipeline"] = deepcopy(
+                        self.filter_pipeline_upstream
+                    ) + bson_loads(active_filter["autosave"]["pipeline"])
+                # same for the auto_followup pipeline:
+                if (
+                    isinstance(active_filter.get("auto_followup", None), dict)
+                    and active_filter.get("auto_followup", {}).get("pipeline", None)
+                    is not None
+                ):
+                    active_filter["auto_followup"]["pipeline"] = deepcopy(
+                        self.filter_pipeline_upstream
+                    ) + bson_loads(active_filter["auto_followup"]["pipeline"])
+
                 filter_template = {
                     "group_id": active_filter["group_id"],
                     "filter_id": active_filter["filter_id"],

--- a/kowalski/alert_brokers/alert_broker_pgir.py
+++ b/kowalski/alert_brokers/alert_broker_pgir.py
@@ -237,6 +237,7 @@ class PGIRAlertWorker(AlertWorker, ABC):
                             "filter_id": 1,
                             "permissions": 1,
                             "autosave": 1,
+                            "auto_followup": 1,
                             "update_annotations": 1,
                             "fv": {
                                 "$arrayElemAt": [
@@ -307,8 +308,11 @@ class PGIRAlertWorker(AlertWorker, ABC):
                     "filter_name": filter_name,
                     "fid": active_filter["fv"]["fid"],
                     "permissions": active_filter["permissions"],
-                    "autosave": active_filter["autosave"],
-                    "update_annotations": active_filter["update_annotations"],
+                    "autosave": active_filter.get("autosave", False),
+                    "auto_followup": active_filter.get("auto_followup", {}),
+                    "update_annotations": active_filter.get(
+                        "update_annotations", False
+                    ),
                     "pipeline": deepcopy(pipeline),
                 }
 

--- a/kowalski/alert_brokers/alert_broker_turbo.py
+++ b/kowalski/alert_brokers/alert_broker_turbo.py
@@ -213,6 +213,7 @@ class TURBOAlertWorker(AlertWorker, ABC):
                             "filter_id": 1,
                             "permissions": 1,
                             "autosave": 1,
+                            "auto_followup": 1,
                             "update_annotations": 1,
                             "fv": {
                                 "$arrayElemAt": [
@@ -283,8 +284,11 @@ class TURBOAlertWorker(AlertWorker, ABC):
                     "filter_name": filter_name,
                     "fid": active_filter["fv"]["fid"],
                     "permissions": active_filter["permissions"],
-                    "autosave": active_filter["autosave"],
-                    "update_annotations": active_filter["update_annotations"],
+                    "autosave": active_filter.get("autosave", False),
+                    "auto_followup": active_filter.get("auto_followup", {}),
+                    "update_annotations": active_filter.get(
+                        "update_annotations", False
+                    ),
                     "pipeline": deepcopy(pipeline),
                 }
 

--- a/kowalski/alert_brokers/alert_broker_turbo.py
+++ b/kowalski/alert_brokers/alert_broker_turbo.py
@@ -277,6 +277,25 @@ class TURBOAlertWorker(AlertWorker, ABC):
                     active_filter["fv"]["pipeline"]
                 )
 
+                # if autosave is a dict with a pipeline key, also add the upstream pipeline to it:
+                if (
+                    isinstance(active_filter.get("autosave", None), dict)
+                    and active_filter.get("autosave", {}).get("pipeline", None)
+                    is not None
+                ):
+                    active_filter["autosave"]["pipeline"] = deepcopy(
+                        self.filter_pipeline_upstream
+                    ) + bson_loads(active_filter["autosave"]["pipeline"])
+                # same for the auto_followup pipeline:
+                if (
+                    isinstance(active_filter.get("auto_followup", None), dict)
+                    and active_filter.get("auto_followup", {}).get("pipeline", None)
+                    is not None
+                ):
+                    active_filter["auto_followup"]["pipeline"] = deepcopy(
+                        self.filter_pipeline_upstream
+                    ) + bson_loads(active_filter["auto_followup"]["pipeline"])
+
                 filter_template = {
                     "group_id": active_filter["group_id"],
                     "filter_id": active_filter["filter_id"],

--- a/kowalski/alert_brokers/alert_broker_winter.py
+++ b/kowalski/alert_brokers/alert_broker_winter.py
@@ -239,6 +239,7 @@ class WNTRAlertWorker(AlertWorker, ABC):
                             "filter_id": 1,
                             "permissions": 1,
                             "autosave": 1,
+                            "auto_followup": 1,
                             "update_annotations": 1,
                             "fv": {
                                 "$arrayElemAt": [
@@ -309,8 +310,11 @@ class WNTRAlertWorker(AlertWorker, ABC):
                     "filter_name": filter_name,
                     "fid": active_filter["fv"]["fid"],
                     "permissions": active_filter["permissions"],
-                    "autosave": active_filter["autosave"],
-                    "update_annotations": active_filter["update_annotations"],
+                    "autosave": active_filter.get("autosave", False),
+                    "auto_followup": active_filter.get("auto_followup", {}),
+                    "update_annotations": active_filter.get(
+                        "update_annotations", False
+                    ),
                     "pipeline": deepcopy(pipeline),
                 }
 

--- a/kowalski/alert_brokers/alert_broker_winter.py
+++ b/kowalski/alert_brokers/alert_broker_winter.py
@@ -303,6 +303,25 @@ class WNTRAlertWorker(AlertWorker, ABC):
                     active_filter["fv"]["pipeline"]
                 )
 
+                # if autosave is a dict with a pipeline key, also add the upstream pipeline to it:
+                if (
+                    isinstance(active_filter.get("autosave", None), dict)
+                    and active_filter.get("autosave", {}).get("pipeline", None)
+                    is not None
+                ):
+                    active_filter["autosave"]["pipeline"] = deepcopy(
+                        self.filter_pipeline_upstream
+                    ) + bson_loads(active_filter["autosave"]["pipeline"])
+                # same for the auto_followup pipeline:
+                if (
+                    isinstance(active_filter.get("auto_followup", None), dict)
+                    and active_filter.get("auto_followup", {}).get("pipeline", None)
+                    is not None
+                ):
+                    active_filter["auto_followup"]["pipeline"] = deepcopy(
+                        self.filter_pipeline_upstream
+                    ) + bson_loads(active_filter["auto_followup"]["pipeline"])
+
                 filter_template = {
                     "group_id": active_filter["group_id"],
                     "filter_id": active_filter["filter_id"],

--- a/kowalski/alert_brokers/alert_broker_ztf.py
+++ b/kowalski/alert_brokers/alert_broker_ztf.py
@@ -236,6 +236,7 @@ class ZTFAlertWorker(AlertWorker, ABC):
                             "filter_id": 1,
                             "permissions": 1,
                             "autosave": 1,
+                            "auto_followup": 1,
                             "update_annotations": 1,
                             "fv": {
                                 "$arrayElemAt": [
@@ -313,8 +314,11 @@ class ZTFAlertWorker(AlertWorker, ABC):
                     "filter_name": filter_name,
                     "fid": active_filter["fv"]["fid"],
                     "permissions": active_filter["permissions"],
-                    "autosave": active_filter["autosave"],
-                    "update_annotations": active_filter["update_annotations"],
+                    "autosave": active_filter.get("autosave", False),
+                    "auto_followup": active_filter.get("auto_followup", {}),
+                    "update_annotations": active_filter.get(
+                        "update_annotations", False
+                    ),
                     "pipeline": deepcopy(pipeline),
                 }
 

--- a/kowalski/alert_brokers/alert_broker_ztf.py
+++ b/kowalski/alert_brokers/alert_broker_ztf.py
@@ -307,6 +307,43 @@ class ZTFAlertWorker(AlertWorker, ABC):
                     "$in"
                 ][1] = active_filter["permissions"]
 
+                # if autosave is a dict with a pipeline key, also add the upstream pipeline to it:
+                if (
+                    isinstance(active_filter.get("autosave", None), dict)
+                    and active_filter.get("autosave", {}).get("pipeline", None)
+                    is not None
+                ):
+                    active_filter["autosave"]["pipeline"] = deepcopy(
+                        self.filter_pipeline_upstream
+                    ) + bson_loads(active_filter["autosave"]["pipeline"])
+                    # set permissions
+                    active_filter["autosave"]["pipeline"][0]["$match"][
+                        "candidate.programid"
+                    ]["$in"] = active_filter["permissions"]
+                    active_filter["autosave"]["pipeline"][3]["$project"][
+                        "prv_candidates"
+                    ]["$filter"]["cond"]["$and"][0]["$in"][1] = active_filter[
+                        "permissions"
+                    ]
+                # same for the auto_followup pipeline:
+                if (
+                    isinstance(active_filter.get("auto_followup", None), dict)
+                    and active_filter.get("auto_followup", {}).get("pipeline", None)
+                    is not None
+                ):
+                    active_filter["auto_followup"]["pipeline"] = deepcopy(
+                        self.filter_pipeline_upstream
+                    ) + bson_loads(active_filter["auto_followup"]["pipeline"])
+                    # set permissions
+                    active_filter["auto_followup"]["pipeline"][0]["$match"][
+                        "candidate.programid"
+                    ]["$in"] = active_filter["permissions"]
+                    active_filter["auto_followup"]["pipeline"][3]["$project"][
+                        "prv_candidates"
+                    ]["$filter"]["cond"]["$and"][0]["$in"][1] = active_filter[
+                        "permissions"
+                    ]
+
                 filter_template = {
                     "group_id": active_filter["group_id"],
                     "filter_id": active_filter["filter_id"],

--- a/kowalski/alert_brokers/alert_broker_ztf.py
+++ b/kowalski/alert_brokers/alert_broker_ztf.py
@@ -135,7 +135,7 @@ class ZTFAlertConsumer(AlertConsumer, ABC):
             # execute user-defined alert filters
             with timer(f"Filtering of {object_id} {candid}", alert_worker.verbose > 1):
                 passed_filters = alert_worker.alert_filter__user_defined(
-                    alert_worker.filter_templates, alert
+                    alert_worker.filter_templates, alert, all_prv_candidates
                 )
             if alert_worker.verbose > 1:
                 log(

--- a/kowalski/api/api.py
+++ b/kowalski/api/api.py
@@ -2430,20 +2430,16 @@ class FilterHandler(Handler):
 
                     if modifiable_field == "autosave" and isinstance(value, bool):
                         pass
-                    elif (
-                        modifiable_field == "autosave"
-                        and isinstance(value, dict)
-                        and "pipeline" not in value
-                    ):
+                    elif isinstance(value, dict) and "pipeline" not in value:
                         pass
-                    elif (
-                        modifiable_field == "auto_followup"
-                        and isinstance(value, dict)
-                        and "pipeline" not in value
-                    ):
-                        return self.error(
-                            message=f"Cannot update filter id {filter_id}: {modifiable_field} must contain a pipeline"
-                        )
+                    # elif (
+                    #     modifiable_field == "auto_followup"
+                    #     and isinstance(value, dict)
+                    #     and "pipeline" not in value
+                    # ):
+                    #     return self.error(
+                    #         message=f"Cannot update filter id {filter_id}: {modifiable_field} must contain a pipeline"
+                    #     )
                     else:
                         pipeline = value.get("pipeline")
                         if not isinstance(pipeline, str):

--- a/kowalski/tests/test_alert_broker_pgir.py
+++ b/kowalski/tests/test_alert_broker_pgir.py
@@ -14,7 +14,7 @@ def worker_fixture(request):
     request.cls.worker = PGIRAlertWorker()
     log("Successfully initialized")
     # do not attempt monitoring filters
-    request.cls.run_forever = False
+    request.cls.worker.run_forever = False
 
 
 @pytest.fixture(autouse=True, scope="class")

--- a/kowalski/tests/test_alert_broker_turbo.py
+++ b/kowalski/tests/test_alert_broker_turbo.py
@@ -14,7 +14,7 @@ def worker_fixture(request):
     request.cls.worker = TURBOAlertWorker()
     log("Successfully initialized")
     # do not attempt monitoring filters
-    request.cls.run_forever = False
+    request.cls.worker.run_forever = False
 
 
 @pytest.fixture(autouse=True, scope="class")

--- a/kowalski/tests/test_alert_broker_wntr.py
+++ b/kowalski/tests/test_alert_broker_wntr.py
@@ -14,7 +14,7 @@ def worker_fixture(request):
     request.cls.worker = WNTRAlertWorker()
     log("Successfully initialized")
     # do not attempt monitoring filters
-    request.cls.run_forever = False
+    request.cls.worker.run_forever = False
 
 
 @pytest.fixture(autouse=True, scope="class")

--- a/kowalski/tests/test_alert_broker_ztf.py
+++ b/kowalski/tests/test_alert_broker_ztf.py
@@ -14,7 +14,7 @@ def worker_fixture(request):
     request.cls.worker = ZTFAlertWorker()
     log("Successfully initialized")
     # do not attempt monitoring filters
-    request.cls.run_forever = False
+    request.cls.worker.run_forever = False
 
 
 @pytest.fixture(autouse=True, scope="class")

--- a/kowalski/tests/test_alert_broker_ztf.py
+++ b/kowalski/tests/test_alert_broker_ztf.py
@@ -200,6 +200,7 @@ class TestAlertBrokerZTF:
         """Test pushing an alert through a filter that also has auto follow-up activated"""
         post_alert(self.worker, self.alert)
         filter = filter_template(self.worker.collection_alerts)
+        filter["autosave"] = True
         filter["auto_followup"] = {
             "active": True,
             "pipeline": [
@@ -213,6 +214,7 @@ class TestAlertBrokerZTF:
             "instrument_id": 1,
             "payload": {  # example payload for SEDM
                 "observation_type": "IFU",
+                "priority": 3,
             },
         }
         passed_filters = self.worker.alert_filter__user_defined([filter], self.alert)
@@ -225,6 +227,7 @@ class TestAlertBrokerZTF:
             passed_filters[0]["auto_followup"]["data"]["payload"]["observation_type"]
             == "IFU"
         )
+        assert passed_filters[0]["auto_followup"]["data"]["payload"]["priority"] == 3
 
     def test_alert_filter__user_defined_followup_with_broker(self):
         """Test pushing an alert through a filter that also has auto follow-up activated, and broker mode activated"""
@@ -293,6 +296,7 @@ class TestAlertBrokerZTF:
             "allocation_id": allocation_id,
             "payload": {  # example payload for SEDM
                 "observation_type": "IFU",
+                "priority": 3,
             },
         }
         passed_filters = self.worker.alert_filter__user_defined([filter], self.alert)
@@ -304,6 +308,7 @@ class TestAlertBrokerZTF:
             passed_filters[0]["auto_followup"]["data"]["payload"]["observation_type"]
             == "IFU"
         )
+        assert passed_filters[0]["auto_followup"]["data"]["payload"]["priority"] == 3
 
         alert, prv_candidates = self.worker.alert_mongify(self.alert)
         self.worker.alert_sentinel_skyportal(alert, prv_candidates, passed_filters)
@@ -321,6 +326,7 @@ class TestAlertBrokerZTF:
         ]
         assert len(followup_requests) == 1
         assert followup_requests[0]["payload"]["observation_type"] == "IFU"
+        assert followup_requests[0]["payload"]["priority"] == 3
 
         # delete the follow-up request
         response = self.worker.api_skyportal(

--- a/kowalski/tests/test_alert_broker_ztf.py
+++ b/kowalski/tests/test_alert_broker_ztf.py
@@ -53,13 +53,13 @@ def filter_template(upstream):
     ] = [0, 1, 2, 3]
 
     template = {
-        "group_id": 1,
+        "group_id": 2,
         "filter_id": 1,
         "group_name": "test_group",
         "filter_name": "test_filter",
         "fid": "r4nd0m",
         "permissions": [0, 1, 2, 3],
-        "autosave": False,
+        "autosave": True,
         "update_annotations": False,
         "pipeline": pipeline,
     }
@@ -184,6 +184,7 @@ class TestAlertBrokerZTF:
         post_alert(self.worker, self.alert)
 
         filter = filter_template(self.worker.collection_alerts)
+        filter["autosave_comment"] = "Saved to BTS by BTSbot."
         filter["auto_followup"] = {
             "active": True,
             "pipeline": [
@@ -193,6 +194,7 @@ class TestAlertBrokerZTF:
                     }
                 }
             ],
+            "comment": "SEDM triggered by BTSbot",
             "allocation_id": allocation_id,
             "payload": {  # example payload for SEDM
                 "observation_type": "IFU",

--- a/kowalski/tests/test_alert_broker_ztf.py
+++ b/kowalski/tests/test_alert_broker_ztf.py
@@ -334,6 +334,11 @@ class TestAlertBrokerZTF:
         filter["autosave"] = {
             **filter["autosave"],
             "ignore_group_ids": [saved_group_id],
+            "comment": "Saved to BTS2 by BTSbot.",
+        }
+        filter["auto_followup"] = {
+            **filter["auto_followup"],
+            "comment": "SEDM triggered by BTSbot2",
         }
 
         passed_filters = self.worker.alert_filter__user_defined([filter], self.alert)

--- a/kowalski/utils.py
+++ b/kowalski/utils.py
@@ -446,7 +446,6 @@ class Mongo:
             return False
 
 
-
 def radec_str2rad(_ra_str, _dec_str):
     """
     :param _ra_str: 'H:M:S'

--- a/kowalski/utils.py
+++ b/kowalski/utils.py
@@ -428,6 +428,17 @@ class Mongo:
                 )
                 traceback.print_exc()
 
+    def delete_one(self, collection: str, document: dict, **kwargs):
+        try:
+            self.db[collection].delete_one(document)
+        except Exception as e:
+            if self.verbose:
+                print(
+                    time_stamp(),
+                    f"Error deleting document from collection {collection}: {str(e)}",
+                )
+                traceback.print_exc()
+
 
 def radec_str2rad(_ra_str, _dec_str):
     """

--- a/kowalski/utils.py
+++ b/kowalski/utils.py
@@ -59,7 +59,7 @@ import pymongo
 from astropy.io import fits
 from motor.motor_asyncio import AsyncIOMotorClient
 from numba import jit
-from pymongo.errors import BulkWriteError
+from pymongo.errors import BulkWriteError, OperationFailure
 from requests.adapters import HTTPAdapter
 
 from kowalski.log import time_stamp, log
@@ -83,6 +83,11 @@ def retry(func, max_retries=10, timeout=6):
             try:
                 return func(*args, **kwargs)
             except Exception as e:
+                # this kind of error is not retryable
+                if type(
+                    e
+                ) == OperationFailure and "Unrecognized pipeline stage name" in str(e):
+                    raise e
                 time.sleep(timeout)
                 n_retries += 1
                 exception = e


### PR DESCRIPTION
This is a work in progress. 

This feature, requested by Nabeel, would help trigger follow-up requests on some alerts with an additional layer of filtering that the one currently used to receive the candidates.

The idea would be that a "normal" filtering pipeline can now have an additional "auto_followup" pipeline. If it passes the normal filter, and that follow-up specific filter, a follow-up request will be created on SkyPortal.

Also, to avoid duplicates, we make sure not to create a request if there is already one that has been submitted.

TODO: 
- [x] Not trigger any followup anymore once there's a completed followup request on the source for that allocation.
- [x] automatically post comments, this could be its own separate PR but given its resemblance the feature will be added here.
- [x] Make sure the API can process these new filtering options.
- [x] Add the same additional filtering logic to the autosave, but optional. It can still be a simple boolean, or a dict with an optional pipeline and a comment to post.
- [x] Fix the tests? Locally, even after passing, it seems like some kind of thread lock blocks pytest from proceeding. So either fixing the lock, and putting a time limit on the tests (which would be bad anyway).
