### PR TITLE
Auto follow-up: cancel if already classified or has spectra

### DIFF
--- a/kowalski/alert_brokers/alert_broker.py
+++ b/kowalski/alert_brokers/alert_broker.py
@@ -1336,7 +1336,10 @@ class AlertWorker:
                                         ).strftime("%Y-%m-%dT%H:%M:%S.%f"),
                                         # one week validity window
                                     },
+                                    # constraints
                                     "source_group_ids": [_filter["group_id"]],
+                                    "not_if_classified": True,
+                                    "not_if_spectra_exists": True,
                                 },
                             }
 

--- a/kowalski/alert_brokers/alert_broker.py
+++ b/kowalski/alert_brokers/alert_broker.py
@@ -1339,7 +1339,7 @@ class AlertWorker:
                                     # constraints
                                     "source_group_ids": [_filter["group_id"]],
                                     "not_if_classified": True,
-                                    "not_if_spectra_exists": True,
+                                    "not_if_spectra_exist": True,
                                 },
                             }
 


### PR DESCRIPTION
This goes in pair with a SkyPortal PR, where we make it possible to cancel triggering a follow-up request if a source is already classified, or already has spectra