### PR TITLE
ML feature bugfix, remove recent photometry addition for latency sake

### DIFF
--- a/kowalski/alert_brokers/alert_broker.py
+++ b/kowalski/alert_brokers/alert_broker.py
@@ -1802,37 +1802,6 @@ class AlertWorker:
             # post alert photometry in single call to /api/photometry
             alert["prv_candidates"] = prv_candidates
 
-            # also get all the alerts for this object, to make sure to have all the detections
-            try:
-                all_alerts = list(
-                    retry(self.mongo.db[self.collection_alerts].find)(
-                        {
-                            "objectId": alert["objectId"],
-                            "candid": {"$ne": alert["candid"]},
-                        },
-                        {
-                            "candidate": 1,
-                        },
-                    )
-                )
-                all_alerts = [
-                    {**a["candidate"]} for a in all_alerts if "candidate" in a
-                ]
-                # add to prv_candidates the detections that are not already in there
-                # use the jd and the fid to match
-                for a in all_alerts:
-                    if not any(
-                        [
-                            (a["jd"] == p["jd"]) and (a["fid"] == p["fid"])
-                            for p in alert["prv_candidates"]
-                        ]
-                    ):
-                        alert["prv_candidates"].append(a)
-                del all_alerts
-            except Exception as e:
-                # this should never happen, but just in case
-                log(f"Failed to get all alerts for {alert['objectId']}: {e}")
-
             self.alert_put_photometry(alert)
 
         if len(autosave_group_ids):

--- a/kowalski/utils.py
+++ b/kowalski/utils.py
@@ -1193,7 +1193,7 @@ class ZTFAlert:
             alert["candidate"].get("jdstarthist", None),
             min(
                 [alert["candidate"]["jd"]]
-                + [a["jd"] for a in alert_history if a["magpsf"] is not None]
+                + [a["jd"] for a in alert_history if a.get("magpsf", None) is not None]
             ),
         )
 


### PR DESCRIPTION
- minor bugfix to the feature generation for ML. This has been hot patched at the beginning of the night in production.
- Don't include all alerts as detections for objects that have already been saved to SP before, as they should have the full lightcurve already anyway (and kowalski already skipped using the full history if an object has already been pushed to Fritz). It doesn't hurt to have it for both existing and non-existing objects, but the problem is latency. Pushing large lightcurves for these old variables takes forever. I wonder if we could speed up the endpoint in SkyPortal itself.