### PR TITLE
Update auto follow-up request priority

### DIFF
--- a/kowalski/alert_brokers/alert_broker.py
+++ b/kowalski/alert_brokers/alert_broker.py
@@ -1996,10 +1996,6 @@ class AlertWorker:
                             # so we'll basically get that from the existing request, and simply update the priority
                             try:
                                 data = {
-                                    "target_group_id": [
-                                        g["id"]
-                                        for g in request_to_update["target_groups"]
-                                    ],
                                     "payload": {
                                         **request_to_update["payload"],
                                         "priority": passed_filter["auto_followup"][
@@ -2007,7 +2003,6 @@ class AlertWorker:
                                         ]["payload"]["priority"],
                                     },
                                     "obj_id": alert["objectId"],
-                                    "status": request_to_update["status"],
                                     "allocation_id": request_to_update["allocation_id"],
                                 }
                                 response = self.api_skyportal(

--- a/kowalski/alert_brokers/alert_broker_ztf.py
+++ b/kowalski/alert_brokers/alert_broker_ztf.py
@@ -75,7 +75,18 @@ class ZTFAlertConsumer(AlertConsumer, ABC):
                 and len(existing_aux.get("prv_candidates", [])) > 0
             ):
                 all_prv_candidates += existing_aux["prv_candidates"]
-            del existing_aux
+
+            # get all alerts for this objectId:
+            existing_alerts = list(
+                alert_worker.mongo.db[alert_worker.collection_alerts].find(
+                    {"objectId": object_id}, {"candidate": 1}
+                )
+            )
+            if len(existing_alerts) > 0:
+                all_prv_candidates += [
+                    existing_alert["candidate"] for existing_alert in existing_alerts
+                ]
+            del existing_aux, existing_alerts
 
         # ML models:
         with timer(f"MLing of {object_id} {candid}", alert_worker.verbose > 1):

--- a/kowalski/utils.py
+++ b/kowalski/utils.py
@@ -1168,6 +1168,26 @@ def str_to_numeric(s):
         return float(s)
 
 
+def compare_dicts(a: dict, b: dict, ignore_keys=[], same_keys=False):
+    """Compare two followup payloads, making sure that a is the same as b or a subset of b, ignoring certain keys"""
+    if same_keys and len(a) != len(b):
+        return False
+    for k, v in a.items():
+        if k in ignore_keys:
+            continue
+        if k not in b:
+            return False
+        if isinstance(v, dict):
+            if not compare_dicts(v, b[k]):
+                return False
+        elif isinstance(v, list):
+            if not all([i in b[k] for i in v]):
+                return False
+        elif b[k] != v:
+            return False
+    return True
+
+
 class ZTFAlert:
     def __init__(self, alert, alert_history, models, label=None, **kwargs):
         self.kwargs = kwargs


### PR DESCRIPTION
This PR does:
- when looking for existing follow-up requests, also look if the existing requests are from the same group, and have the same payload.
- if a request exists, but the last candidate passed a filter that yielded a higher priority than the existing request's priority, update it with the new priority value.

Also, a minor change to try to get around the current issues with missing data: When building the "all_prv_candidates"/alert_history list used for ML feature generation, also append the full history of alerts, not just prv_candidates. This should help BTSbot not have high scores on old variables.

A few questions for the reviewers:
@mcoughlin is it correct that updating a request's priority (so effectively, the payload) tells the instrument of the allocation to update it? Just making sure it doesn't just give us the illusion to do so. If that's the case, we might want to delete and recreate instead, which comes with it's own challenges. 
-> UPDATE: I checked and it should! At least this is implemented for SEDM's API class.

@nabeelre, given the additional cut on group_id when looking for existing requests, this means that if SEDM has pending or completed requests with either another allocation, or the same allocation but not shared with the auto-triggering group where you have your filter (which should be the case for existing requests), or has a different payload, ... and hasn't been classified and didn't get a spectra, we might still trigger SEDM. Just wanted to make sure that this is the expected behavior. I think it is, given the data access constraints we talked about earlier.