### PR TITLE
ZTF Alert FP - deduplication logic, flux to mag space

### DIFF
--- a/kowalski/alert_brokers/alert_broker.py
+++ b/kowalski/alert_brokers/alert_broker.py
@@ -2003,7 +2003,7 @@ class AlertWorker:
                                                     .get("data", {})
                                                     .get(
                                                         "message",
-                                                        "unknow error posting comment",
+                                                        "unknown error posting comment",
                                                     )
                                                 )
                                         except Exception as e:
@@ -2018,12 +2018,12 @@ class AlertWorker:
                                         .get("data", {})
                                         .get(
                                             "message",
-                                            "unknow error posting followup request",
+                                            "unknown error posting followup request",
                                         ),
                                     )
                                 except Exception:
                                     error_message = (
-                                        "unknow error posting followup request"
+                                        "unknown error posting followup request"
                                     )
                                 raise ValueError(error_message)
                         except Exception as e:
@@ -2098,7 +2098,7 @@ class AlertWorker:
                                     raise ValueError(
                                         response.json().get(
                                             "message",
-                                            "unknow error updating followup request",
+                                            "unknown error updating followup request",
                                         )
                                     )
                             except Exception as e:

--- a/kowalski/alert_brokers/alert_broker_ztf.py
+++ b/kowalski/alert_brokers/alert_broker_ztf.py
@@ -565,7 +565,7 @@ class ZTFAlertWorker(AlertWorker, ABC):
             # 5. group all the deduplicated fp_hists back into an array
             # 6. update the document
             # TODO: find a way to run the update at the same time as we create the new deduplicated array,
-            # to avoid potential (even if very unlickely) concurrency issues as much as possible.
+            # to avoid potential (even if very unlikely) concurrency issues as much as possible.
             update_pipeline = [
                 {
                     "$project": {

--- a/kowalski/alert_brokers/alert_broker_ztf.py
+++ b/kowalski/alert_brokers/alert_broker_ztf.py
@@ -505,8 +505,12 @@ class ZTFAlertWorker(AlertWorker, ABC):
         magerr = 1.0857 * (values[1] / values[0])
         limmag3sig = -2.5 * np.log10(3 * values[1]) + values[2]
         limmag5sig = -2.5 * np.log10(5 * values[1]) + values[2]
-        if snr < 0:
+        if np.isnan(snr):
             return {}
+        if snr < 0:
+            return {
+                "snr": snr,
+            }
         mag_data = {
             "mag": mag,
             "magerr": magerr,

--- a/kowalski/ingesters/ingester.py
+++ b/kowalski/ingesters/ingester.py
@@ -233,10 +233,13 @@ class KafkaStream:
             os.remove(meta_properties)
 
     def __enter__(self):
-        # call the start method asynchonously, so it keeps running in the background and we can return
-        # the KafkaStream object to the caller
-        # only do this if we are not in test mode
-        if not self.test:
+        # when not in test mode, call the start method in a separate thread
+        # this helps so that you can start polling the topic right away
+        # otherwise, the start method will block until all alerts are ingested
+        # which is not possible if you are ingesting more alerts than the queue size
+        if self.test:
+            self.start()
+        else:
             threading.Thread(target=self.start).start()
         self.as_context_manager = True
         time.sleep(15)  # give it a chance to finish ingesting properly

--- a/kowalski/ingesters/ingester.py
+++ b/kowalski/ingesters/ingester.py
@@ -4,6 +4,7 @@ import subprocess
 import time
 from confluent_kafka import Producer
 from kowalski.log import log
+import threading
 
 
 def delivery_report(err, msg):
@@ -18,11 +19,20 @@ def delivery_report(err, msg):
 class KafkaStream:
     as_context_manager = False
 
-    def __init__(self, topic, path_alerts, config, test=False):
+    def __init__(self, topic, path_alerts, config, test=False, **kwargs):
         self.config = config
         self.topic = topic
         self.path_alerts = path_alerts
         self.test = test
+
+        if kwargs.get("max_alerts") is not None:
+            try:
+                int(kwargs.get("max_alerts"))
+            except ValueError:
+                raise ValueError("max_alerts must be an integer")
+            self.max_alerts = int(kwargs.get("max_alerts"))
+        else:
+            self.max_alerts = None
 
     def start(self):
         # create a kafka topic and start a producer to stream the alerts
@@ -148,7 +158,11 @@ class KafkaStream:
             }
         )
 
-        for p in self.path_alerts.glob("*.avro"):
+        alerts = list(self.path_alerts.glob("*.avro"))
+        if self.max_alerts is not None:
+            alerts = alerts[: self.max_alerts]
+        log(f"Streaming {len(alerts)} alerts")
+        for p in alerts:
             with open(str(p), "rb") as data:
                 # Trigger any available delivery report callbacks from previous produce() calls
                 producer.poll(0)
@@ -158,7 +172,18 @@ class KafkaStream:
                 # Asynchronously produce a message, the delivery report callback
                 # will be triggered from poll() above, or flush() below, when the message has
                 # been successfully delivered or failed permanently.
-                producer.produce(self.topic, data.read(), callback=delivery_report)
+                while True:
+                    try:
+                        producer.produce(
+                            self.topic, data.read(), callback=delivery_report
+                        )
+                        break
+                    except BufferError:
+                        print(
+                            "Local producer queue is full (%d messages awaiting delivery): try again\n"
+                            % len(producer)
+                        )
+                        time.sleep(1)
 
                 # Wait for any outstanding messages to be delivered and delivery report
                 # callbacks to be triggered.
@@ -208,7 +233,11 @@ class KafkaStream:
             os.remove(meta_properties)
 
     def __enter__(self):
-        self.start()
+        # call the start method asynchonously, so it keeps running in the background and we can return
+        # the KafkaStream object to the caller
+        # only do this if we are not in test mode
+        if not self.test:
+            threading.Thread(target=self.start).start()
         self.as_context_manager = True
         time.sleep(15)  # give it a chance to finish ingesting properly
         return self

--- a/kowalski/tests/test_alert_broker_ztf.py
+++ b/kowalski/tests/test_alert_broker_ztf.py
@@ -268,7 +268,7 @@ class TestAlertBrokerZTF:
         assert all([aux["fp_hists"][i]["alert_mag"] == alert_mag for i in range(14)])
         assert all([aux["fp_hists"][i]["alert_mag"] == 30.0 for i in range(14, 19)])
 
-        # verify that their are still in order by jd (oldest to newest)
+        # verify they are still in order by jd (oldest to newest)
         assert all(
             [
                 aux["fp_hists"][i]["jd"] < aux["fp_hists"][i + 1]["jd"]
@@ -300,7 +300,7 @@ class TestAlertBrokerZTF:
         assert all([aux["fp_hists"][i]["alert_mag"] == alert_mag for i in range(11)])
         assert all([aux["fp_hists"][i]["alert_mag"] == 15.0 for i in range(11, 21)])
 
-        # verify that their are still in order by jd (oldest to newest)
+        # verify they are still in order by jd (oldest to newest)
         assert all(
             [
                 aux["fp_hists"][i]["jd"] < aux["fp_hists"][i + 1]["jd"]

--- a/kowalski/tests/test_alert_broker_ztf.py
+++ b/kowalski/tests/test_alert_broker_ztf.py
@@ -67,21 +67,58 @@ def filter_template(upstream):
     return template
 
 
-def post_alert(worker, alert):
-    alert, _, _ = worker.alert_mongify(alert)
+def post_alert(worker: ZTFAlertWorker, alert, fp_cutoff=1):
+    delete_alert(worker, alert)
+    alert, prv_candidates, fp_hists = worker.alert_mongify(alert)
     # check if it already exists
     if worker.mongo.db[worker.collection_alerts].count_documents(
         {"candid": alert["candid"]}
     ):
         log(f"Alert {alert['candid']} already exists, skipping")
-        return
-    worker.mongo.insert_one(collection=worker.collection_alerts, document=alert)
+    else:
+        worker.mongo.insert_one(collection=worker.collection_alerts, document=alert)
+
+    if worker.mongo.db[worker.collection_alerts_aux].count_documents(
+        {"_id": alert["objectId"]}
+    ):
+        # delete if it exists
+        worker.mongo.delete_one(
+            collection=worker.collection_alerts_aux,
+            document={"_id": alert["objectId"]},
+        )
+
+    # fp_hists: pop nulls - save space
+    fp_hists = [
+        {kk: vv for kk, vv in fp_hist.items() if vv not in [None, -99999, -99999.0]}
+        for fp_hist in fp_hists
+    ]
+
+    fp_hists = worker.format_fp_hists(alert, fp_hists)
+
+    # sort fp_hists by jd
+    fp_hists = sorted(fp_hists, key=lambda x: x["jd"])
+
+    if fp_cutoff < 1:
+        index = int(fp_cutoff * len(fp_hists))
+        fp_hists = fp_hists[:index]
+
+    aux = {
+        "_id": alert["objectId"],
+        "prv_candidates": prv_candidates,
+        "cross_matches": {},
+        "fp_hists": fp_hists,
+    }
+    worker.mongo.insert_one(collection=worker.collection_alerts_aux, document=aux)
 
 
 def delete_alert(worker, alert):
     worker.mongo.delete_one(
         collection=worker.collection_alerts,
         document={"candidate.candid": alert["candid"]},
+    )
+    worker.mongo.delete_one(
+        collection=worker.collection_alerts_aux,
+        document={"_id": alert["objectId"]},
     )
 
 
@@ -155,6 +192,121 @@ class TestAlertBrokerZTF:
                 #     )
                 #     for k in new_fp_hists[i].keys():
                 #         assert new_fp_hists[i][k] == fp_hists[i][k]
+
+    def test_ingest_alert_with_fp_hists(self):
+        candid = 2475433850015010009
+        sample_avro = f"data/ztf_alerts/20231012/{candid}.avro"
+        alert_mag = 21.0
+        fp_hists = []
+        with open(sample_avro, "rb") as f:
+            records = [record for record in fastavro.reader(f)]
+            for record in records:
+                # delete_alert(self.worker, record)
+                alert, prv_candidates, fp_hists = self.worker.alert_mongify(record)
+                alert_mag = alert["candidate"]["magpsf"]
+                post_alert(self.worker, record, fp_cutoff=0.7)
+
+        # verify that the alert was ingested
+        assert (
+            self.worker.mongo.db[self.worker.collection_alerts].count_documents(
+                {"candid": candid}
+            )
+            == 1
+        )
+        assert (
+            self.worker.mongo.db[self.worker.collection_alerts_aux].count_documents(
+                {"_id": record["objectId"]}
+            )
+            == 1
+        )
+
+        # verify that fp_hists was ingested correctly
+        aux = self.worker.mongo.db[self.worker.collection_alerts_aux].find_one(
+            {"_id": record["objectId"]}
+        )
+        assert "fp_hists" in aux
+        assert len(aux["fp_hists"]) == 14  # we had a cutoff at 21 * 0.7 = 14.7, so 14
+
+        # print("---------- Original ----------")
+        # for fp in aux["fp_hists"]:
+        #     print(f"{fp['jd']}: {fp['alert_mag']}")
+
+        # fp_hists: pop nulls - save space and make sure its the same as what is in the DB
+        fp_hists = [
+            {kk: vv for kk, vv in fp_hist.items() if vv not in [None, -99999, -99999.0]}
+            for fp_hist in fp_hists
+        ]
+
+        # sort fp_hists by jd
+        fp_hists = sorted(fp_hists, key=lambda x: x["jd"])
+
+        # now, let's try the alert worker's update_fp_hists method, passing it the full fp_hists
+        # and verify that it we have 21 exactly
+
+        # first we add some forced photometry, where we have new rows, but overlapping rows from a fainter alert
+        record["candidate"]["magpsf"] = 30.0
+        # keep the last 10 fp_hists
+        fp_hists_copy = fp_hists[-10:]
+        # remove the last 2
+        fp_hists_copy = fp_hists_copy[:-2]
+
+        fp_hists_formatted = self.worker.format_fp_hists(alert, fp_hists_copy)
+        self.worker.update_fp_hists(record, fp_hists_formatted)
+
+        aux = self.worker.mongo.db[self.worker.collection_alerts_aux].find_one(
+            {"_id": record["objectId"]}
+        )
+        # print(aux)
+        assert "fp_hists" in aux
+        assert len(aux["fp_hists"]) == 19
+
+        # print("---------- First update ----------")
+        # for fp in aux["fp_hists"]:
+        #     print(f"{fp['jd']}: {fp['alert_mag']}")
+
+        # we should have the same first 14 fp_hists as before, then the new ones
+        assert all([aux["fp_hists"][i]["alert_mag"] == alert_mag for i in range(14)])
+        assert all([aux["fp_hists"][i]["alert_mag"] == 30.0 for i in range(14, 19)])
+
+        # verify that their are still in order by jd (oldest to newest)
+        assert all(
+            [
+                aux["fp_hists"][i]["jd"] < aux["fp_hists"][i + 1]["jd"]
+                for i in range(len(aux["fp_hists"]) - 1)
+            ]
+        )
+
+        # now, the last 10 datapoints, but as if they were from a brighter alert
+        # we should have an overlap with both the original FP, and the datapoints (from faint alert) we just added
+        record["candidate"]["magpsf"] = 15.0
+        # keep the last 10 fp_hists
+        fp_hists_copy = fp_hists[-10:]
+
+        fp_hists_formatted = self.worker.format_fp_hists(alert, fp_hists_copy)
+        self.worker.update_fp_hists(record, fp_hists_formatted)
+
+        aux = self.worker.mongo.db[self.worker.collection_alerts_aux].find_one(
+            {"_id": record["objectId"]}
+        )
+
+        assert "fp_hists" in aux
+        assert len(aux["fp_hists"]) == 21
+
+        # print("---------- Last update ----------")
+        # for fp in aux["fp_hists"]:
+        #     print(f"{fp['jd']}: {fp['alert_mag']}")
+
+        # the result should be 21 fp_hists, with the first 11 being the same as before, and the last 10 being the same as the new fp_hists
+        assert all([aux["fp_hists"][i]["alert_mag"] == alert_mag for i in range(11)])
+        assert all([aux["fp_hists"][i]["alert_mag"] == 15.0 for i in range(11, 21)])
+
+        # verify that their are still in order by jd (oldest to newest)
+        assert all(
+            [
+                aux["fp_hists"][i]["jd"] < aux["fp_hists"][i + 1]["jd"]
+                for i in range(len(aux["fp_hists"]) - 1)
+            ]
+        )
 
     def test_make_photometry(self):
         df_photometry = self.worker.make_photometry(self.alert)

--- a/kowalski/tools/kafka_stream.py
+++ b/kowalski/tools/kafka_stream.py
@@ -21,12 +21,18 @@ parser.add_argument(
     type=bool,
     help="test mode. if in test mode, alerts will be pushed to bootstarp.test.server",
 )
-
+parser.add_argument(
+    "--max_alerts",
+    type=int,
+    default=None,
+    help="maximum number of alerts to stream (optional)",
+)
 args = parser.parse_args()
 
 topic = args.topic
 path_alerts = args.path_alerts
 test = args.test
+max_alerts = args.max_alerts
 
 if not isinstance(topic, str) or topic == "":
     raise ValueError("topic must be a non-empty string")
@@ -48,6 +54,7 @@ stream = KafkaStream(
     path_alerts=pathlib.Path(f"data/{path_alerts}"),
     test=test,
     config=config,
+    max_alerts=max_alerts,
 )
 
 running = True
@@ -56,7 +63,9 @@ while running:
     # if the user hits Ctrl+C, stop the stream
     try:
         stream.start()
-        time.sleep(1000000000)
+        while True:
+            time.sleep(60)
+            print("heartbeat")
     except KeyboardInterrupt:
         print("\nStopping Kafka stream...")
         stream.stop()


### PR DESCRIPTION
This PR:
- add the deduplication logic folks decided to use, i.e. when we have overlapping FP datapoints, replace existing ones only if the new alert is brighter (which means, the position should be more accurate).
- add mag space information when the SNR is above 0. That way, filters that need the mag can trust it or not trust it by enforcing their own SNR cuts.
- ensure that only brand new ZTF objects start accumulating forced photometry. That way, we either don't have FP, or we have the full history for that object. Otherwise, filters relying on FP could yield unpredictable results.
- add tests for the deduplication

TODO: add tests for the mag space data maybe?