### PR TITLE
Forced photometry update pipeline - missing match stage

### DIFF
--- a/kowalski/alert_brokers/alert_broker_ztf.py
+++ b/kowalski/alert_brokers/alert_broker_ztf.py
@@ -559,6 +559,8 @@ class ZTFAlertWorker(AlertWorker, ABC):
             self.verbose > 1,
         ):
             update_pipeline = [
+                # 0. match the document
+                {"$match": {"_id": alert["objectId"]}},
                 # 1. concat the new fp_hists with the existing ones
                 {
                     "$project": {
@@ -617,6 +619,7 @@ class ZTFAlertWorker(AlertWorker, ABC):
                     self.mongo.db[self.collection_alerts_aux]
                     .aggregate(
                         update_pipeline,
+                        allowDiskUse=True,
                     )
                     .next()
                     .get("fp_hists", [])


### PR DESCRIPTION
That had been hot patched early on in production (without it, it just got stuck and didn't even finish running any query anyway, so none of the resulting data in the DB has been affected), but adding it here to not forget later on.