### PR TITLE
Allow longer timeouts for some API calls

### DIFF
--- a/kowalski/alert_brokers/alert_broker.py
+++ b/kowalski/alert_brokers/alert_broker.py
@@ -486,12 +486,15 @@ class AlertWorker:
             )
         log("AlertWorker setup complete")
 
-    def api_skyportal(self, method: str, endpoint: str, data: Optional[Mapping] = None):
+    def api_skyportal(
+        self, method: str, endpoint: str, data: Optional[Mapping] = None, **kwargs
+    ):
         """Make an API call to a SkyPortal instance
 
         :param method:
         :param endpoint:
         :param data:
+        :param kwargs:
         :return:
         """
         method = method.lower()
@@ -509,6 +512,8 @@ class AlertWorker:
         if method not in ["head", "get", "post", "put", "patch", "delete"]:
             raise ValueError(f"Unsupported method: {method}")
 
+        timeout = kwargs.get("timeout", 5)
+
         if method == "get":
             response = methods[method](
                 f"{config['skyportal']['protocol']}://"
@@ -516,6 +521,7 @@ class AlertWorker:
                 f"{endpoint}",
                 params=data,
                 headers=self.session_headers,
+                timeout=timeout,
             )
         else:
             response = methods[method](
@@ -524,6 +530,7 @@ class AlertWorker:
                 f"{endpoint}",
                 json=data,
                 headers=self.session_headers,
+                timeout=timeout,
             )
 
         return response
@@ -1367,11 +1374,9 @@ class AlertWorker:
                             if not isinstance(_filter.get("autosave", False), bool):
                                 passed_filter["auto_followup"]["data"][
                                     "ignore_source_group_ids"
-                                ] = [
-                                    _filter.get("autosave", {}).get(
-                                        "ignore_group_ids", []
-                                    )
-                                ]
+                                ] = _filter.get("autosave", {}).get(
+                                    "ignore_group_ids", []
+                                )
 
                     passed_filters.append(passed_filter)
 

--- a/kowalski/alert_brokers/alert_broker_ztf.py
+++ b/kowalski/alert_brokers/alert_broker_ztf.py
@@ -475,7 +475,7 @@ class ZTFAlertWorker(AlertWorker, ABC):
                 ):
                     try:
                         response = self.api_skyportal(
-                            "PUT", "/api/photometry", photometry
+                            "PUT", "/api/photometry", photometry, timeout=15
                         )
                         if response.json()["status"] == "success":
                             log(

--- a/kowalski/api/api.py
+++ b/kowalski/api/api.py
@@ -3296,18 +3296,23 @@ class SkymapHandler(Handler):
 
         # check if the skymap already exists
 
+        query = {
+            "$and": [
+                {
+                    "$or": [
+                        {"dateobs": dateobs},
+                        {"triggerid": triggerid},
+                    ],
+                },
+                {"localization_name": skymap["localization_name"]},
+            ]
+        }
+        if len(aliases) > 0:
+            query["$and"][0]["$or"].append({"aliases": {"$all": aliases}})
+
         existing_skymap = await request.app["mongo"][
             config["database"]["collections"]["skymaps"]
-        ].find_one(
-            {
-                "$or": [
-                    {"dateobs": dateobs},
-                    {"triggerid": triggerid},
-                    {"aliases": {"$all": aliases}},
-                ],
-                "localization_name": skymap["localization_name"],
-            }
-        )
+        ].find_one(query)
 
         existing_contour_levels = []
         missing_contour_levels = []


### PR DESCRIPTION
I've seen in production that posting the photometry of some of these older sources (ZTF18, ZTF19, ...) sometimes fails, meaning that the 5-second timeout enforced on all API calls isn't enough.

To solve this we definitely should also look at the SkyPortal endpoint itself to make it faster if possible, but it would be good to also allow specific - larger - timeouts when running some API calls. 5 seconds seems too short when posting large lightcurves (older objects that haven't been saved in SkyPortal yet, for which we post the full lightcurve) given that we put a lock on the table which adds latency on top of the Python code-induced latency.