### PR TITLE
Parallelize topics - consumer groups

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -39,6 +39,8 @@ kowalski:
     bootstrap.test.servers: "localhost:9092"
     zookeeper.test: "localhost:2181"
     path: "kafka_2.13-3.4.1"
+    processes_per_topic:
+      ZTF: 1
 
   database:
     max_pool_size: 200

--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -40,7 +40,7 @@ kowalski:
     zookeeper.test: "localhost:2181"
     path: "kafka_2.13-3.4.1"
     processes_per_topic:
-      ZTF: 1
+      ZTF: 2
 
   database:
     max_pool_size: 200

--- a/kowalski/alert_brokers/alert_broker_ztf.py
+++ b/kowalski/alert_brokers/alert_broker_ztf.py
@@ -891,7 +891,9 @@ def watchdog(obs_date: str = None, test: bool = False):
 
                     for i in range(processes_per_topic):
                         topics_on_watch[t][i].daemon = True
-                        log(f"set daemon to true {topics_on_watch}")
+                        log(
+                            f"set daemon to true for thread {i} topic {topics_on_watch}"
+                        )
                         topics_on_watch[t][i].start()
 
                 else:


### PR DESCRIPTION
This PR allows us to have more than one consumer reading a single topic. By creating multiple consumers on the same topic, but ensuring that they use the same `group.id`, kafka will divide the partitions of a topic between the consumers subscribed to it. This should allow us to read topics quicker, though networking can still be a limiting factor.

In the future, we can definitely consider having a dynamic number of consumers, adding and removing consumers as we accumulate delay/lag. Also, we might want to read the number of partitions on a topic to make sure we don't create more consumers than partitions (in which case we would have idle consumers).