### PR TITLE
Forced Photometry - missing ZTF filter config

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -379,6 +379,31 @@ kowalski:
                           },
                       },
                   },
+                "fp_hists":
+                  {
+                    "$filter":
+                      {
+                        "input": { "$arrayElemAt": ["$aux.fp_hists", 0] },
+                        "as": "item",
+                        "cond":
+                          {
+                            "$and":
+                              [
+                                { "$in": ["$$item.programid", null] },
+                                {
+                                  "$lt":
+                                    [
+                                      {
+                                        "$subtract":
+                                          ["$candidate.jd", "$$item.jd"],
+                                      },
+                                      365,
+                                    ],
+                                },
+                              ],
+                          },
+                      },
+                  },
                 "schemavsn": 1,
                 "publisher": 1,
                 "objectId": 1,


### PR DESCRIPTION
Missing a config block in the ZTF filter aggregate pipeline we apply on top of the filters that run in prod.

With that fix, and running a modified version of the current em+gw filter that uses FP data, it's pretty cool to see that I can get some candidates to pass the filter that usually wouldn't.

But, good to know and keep in mind that a lot of these candidates that pass the filter thanks to the addition of forced photometry don't have very high drb scores...