### PR TITLE
Auto-triggering: cancel if obj has TNS SN designation in SkyPortal

### DIFF
--- a/kowalski/alert_brokers/alert_broker.py
+++ b/kowalski/alert_brokers/alert_broker.py
@@ -1368,6 +1368,7 @@ class AlertWorker:
                                     "source_group_ids": [_filter["group_id"]],
                                     "not_if_classified": True,
                                     "not_if_spectra_exist": True,
+                                    "not_if_tns_classified": True,
                                 },
                             }
 


### PR DESCRIPTION
This uses the follow-up constraints concept on Fritz, that allows an API POST call to be cancelled if some conditions are met. Here, we cancel automatic triggering if there are any nearby sources (0.5 arcsec) in SkyPortal that already have a TNS SN designation (and for which getting a spectrum with low-latency isn't useful as we already have classification).