### PR TITLE
Filter templates: permissions for fp_hists

### DIFF
--- a/kowalski/alert_brokers/alert_broker_ztf.py
+++ b/kowalski/alert_brokers/alert_broker_ztf.py
@@ -355,6 +355,10 @@ class ZTFAlertWorker(AlertWorker, ABC):
                 pipeline[3]["$project"]["prv_candidates"]["$filter"]["cond"]["$and"][0][
                     "$in"
                 ][1] = active_filter["permissions"]
+                if "fp_hists" in pipeline[3]["$project"]:
+                    pipeline[3]["$project"]["fp_hists"]["$filter"]["cond"]["$and"][0][
+                        "$in"
+                    ][1] = active_filter["permissions"]
 
                 # if autosave is a dict with a pipeline key, also add the upstream pipeline to it:
                 if (


### PR DESCRIPTION
ZTF is finally back on sky, and with it comes the first errors 😉. 

Last week I added the missing bits of config needed for the filters that use fp_hists to run as expected. Only now that this is added, did I notice that the method that builds the filters (by adding these extra first steps from the config on top of every pipelines) needed me to hardcode something for the fp_hists. 

This makes me think that using the config for these "base filters" is completely useless if we then need to hardcode things in the code itself. Maybe I can make it a little smarter than it is in a following PR, that can recognize filtering stages that use the `programid` and automagically enforce the permissions there or smth. 

Ideally, we would want similar templating behaviors running on queries from the API to enforce data access permissions even through penquins (which is not the case right now, and we rely on the few users that have acces to it to do so. But that number is growing).