### PR TITLE
WIP - POST Alert-based Forced Photometry to SkyPortal

### DIFF
--- a/ingester.Dockerfile
+++ b/ingester.Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /kowalski
 
 # Install jdk, mkdirs, fetch and install Kafka
 RUN apt-get update && apt-get install -y default-jdk && \
-    wget https://downloads.apache.org/kafka/$kafka_version/kafka_$scala_version-$kafka_version.tgz -O kafka_$scala_version-$kafka_version.tgz && \
+    wget https://archive.apache.org/dist/kafka/$kafka_version/kafka_$scala_version-$kafka_version.tgz -O kafka_$scala_version-$kafka_version.tgz && \
     tar -xzf kafka_$scala_version-$kafka_version.tgz
 
 # Kafka test-server properties:
@@ -42,73 +42,73 @@ COPY data/ztf_source_classifications/ data/ztf_source_classifications/
 COPY data/turbo_alerts/ data/turbo_alerts/
 
 COPY ["kowalski/__init__.py", \
-        "kowalski/utils.py", \
-        "kowalski/config.py", \
-        "kowalski/log.py", \
-        "kowalski/"]
+    "kowalski/utils.py", \
+    "kowalski/config.py", \
+    "kowalski/log.py", \
+    "kowalski/"]
 
 # write the same copy lines above but as a single line:
 COPY ["kowalski/tools/__init__.py", \
-        "kowalski/tools/check_app_environment.py", \
-        "kowalski/tools/check_db_entries.py", \
-        "kowalski/tools/fetch_ztf_alerts.py", \
-        "kowalski/tools/fetch_ztf_matchfiles.py", \
-        "kowalski/tools/generate_supervisord_conf.py", \
-        "kowalski/tools/init_models.py", \
-        "kowalski/tools/init_kafka.py", \
-        "kowalski/tools/istarmap.py", \
-        "kowalski/tools/kafka_stream.py", \
-        "kowalski/tools/ops_watcher_ztf.py", \
-        "kowalski/tools/performance_reporter.py", \
-        "kowalski/tools/pip_install_requirements.py", \
-        "kowalski/tools/tns_watcher.py", \
-        "kowalski/tools/watch_logs.py", \
-        "kowalski/tools/"]
+    "kowalski/tools/check_app_environment.py", \
+    "kowalski/tools/check_db_entries.py", \
+    "kowalski/tools/fetch_ztf_alerts.py", \
+    "kowalski/tools/fetch_ztf_matchfiles.py", \
+    "kowalski/tools/generate_supervisord_conf.py", \
+    "kowalski/tools/init_models.py", \
+    "kowalski/tools/init_kafka.py", \
+    "kowalski/tools/istarmap.py", \
+    "kowalski/tools/kafka_stream.py", \
+    "kowalski/tools/ops_watcher_ztf.py", \
+    "kowalski/tools/performance_reporter.py", \
+    "kowalski/tools/pip_install_requirements.py", \
+    "kowalski/tools/tns_watcher.py", \
+    "kowalski/tools/watch_logs.py", \
+    "kowalski/tools/"]
 
 COPY ["kowalski/dask_clusters/__init__.py", \
-        "kowalski/dask_clusters/dask_cluster.py", \
-        "kowalski/dask_clusters/dask_cluster_pgir.py", \
-        "kowalski/dask_clusters/dask_cluster_winter.py", \
-        "kowalski/dask_clusters/dask_cluster_turbo.py", \
-        "kowalski/dask_clusters/"]
+    "kowalski/dask_clusters/dask_cluster.py", \
+    "kowalski/dask_clusters/dask_cluster_pgir.py", \
+    "kowalski/dask_clusters/dask_cluster_winter.py", \
+    "kowalski/dask_clusters/dask_cluster_turbo.py", \
+    "kowalski/dask_clusters/"]
 
 COPY ["kowalski/alert_brokers/__init__.py", \
-        "kowalski/alert_brokers/alert_broker.py", \
-        "kowalski/alert_brokers/alert_broker_ztf.py", \
-        "kowalski/alert_brokers/alert_broker_pgir.py", \
-        "kowalski/alert_brokers/alert_broker_winter.py", \
-        "kowalski/alert_brokers/alert_broker_turbo.py", \
-        "kowalski/alert_brokers/"]
+    "kowalski/alert_brokers/alert_broker.py", \
+    "kowalski/alert_brokers/alert_broker_ztf.py", \
+    "kowalski/alert_brokers/alert_broker_pgir.py", \
+    "kowalski/alert_brokers/alert_broker_winter.py", \
+    "kowalski/alert_brokers/alert_broker_turbo.py", \
+    "kowalski/alert_brokers/"]
 
 
 COPY ["kowalski/ingesters/__init__.py", \
-        "kowalski/ingesters/ingest_catalog.py", \
-        "kowalski/ingesters/ingest_gaia_edr3.py", \
-        "kowalski/ingesters/ingest_igaps.py", \
-        "kowalski/ingesters/ingest_ps1_strm.py", \
-        "kowalski/ingesters/ingest_ptf_matchfiles.py", \
-        "kowalski/ingesters/ingest_turbo.py", \
-        "kowalski/ingesters/ingest_vlass.py", \
-        "kowalski/ingesters/ingest_ztf_alert_aux.py", \
-        "kowalski/ingesters/ingest_ztf_matchfiles.py", \
-        "kowalski/ingesters/ingest_ztf_public.py", \
-        "kowalski/ingesters/ingest_ztf_source_classifications.py", \
-        "kowalski/ingesters/ingest_ztf_source_features.py", \
-        "kowalski/ingesters/ingester.py", \
-        "kowalski/ingesters/"]
+    "kowalski/ingesters/ingest_catalog.py", \
+    "kowalski/ingesters/ingest_gaia_edr3.py", \
+    "kowalski/ingesters/ingest_igaps.py", \
+    "kowalski/ingesters/ingest_ps1_strm.py", \
+    "kowalski/ingesters/ingest_ptf_matchfiles.py", \
+    "kowalski/ingesters/ingest_turbo.py", \
+    "kowalski/ingesters/ingest_vlass.py", \
+    "kowalski/ingesters/ingest_ztf_alert_aux.py", \
+    "kowalski/ingesters/ingest_ztf_matchfiles.py", \
+    "kowalski/ingesters/ingest_ztf_public.py", \
+    "kowalski/ingesters/ingest_ztf_source_classifications.py", \
+    "kowalski/ingesters/ingest_ztf_source_features.py", \
+    "kowalski/ingesters/ingester.py", \
+    "kowalski/ingesters/"]
 
 
 COPY ["kowalski/tests/test_alert_broker_ztf.py", \
-        "kowalski/tests/test_alert_broker_pgir.py", \
-        "kowalski/tests/test_alert_broker_wntr.py", \
-        "kowalski/tests/test_alert_broker_turbo.py", \
-        "kowalski/tests/test_ingester_ztf.py", \
-        "kowalski/tests/test_ingester_pgir.py", \
-        "kowalski/tests/test_ingester_wntr.py", \
-        "kowalski/tests/test_ingester_turbo.py", \
-        "kowalski/tests/test_tns_watcher.py", \
-        "kowalski/tests/test_tools.py", \
-        "kowalski/tests/"]
+    "kowalski/tests/test_alert_broker_pgir.py", \
+    "kowalski/tests/test_alert_broker_wntr.py", \
+    "kowalski/tests/test_alert_broker_turbo.py", \
+    "kowalski/tests/test_ingester_ztf.py", \
+    "kowalski/tests/test_ingester_pgir.py", \
+    "kowalski/tests/test_ingester_wntr.py", \
+    "kowalski/tests/test_ingester_turbo.py", \
+    "kowalski/tests/test_tns_watcher.py", \
+    "kowalski/tests/test_tools.py", \
+    "kowalski/tests/"]
 
 COPY conf/supervisord_ingester.conf.template conf/
 

--- a/kowalski/alert_brokers/alert_broker.py
+++ b/kowalski/alert_brokers/alert_broker.py
@@ -1591,7 +1591,6 @@ class AlertWorker:
                     log(
                         f"Saved {alert['objectId']} {alert['candid']} as a Source on SkyPortal"
                     )
-                    print(response.json())
                     saved_to_groups = response.json()["data"].get(
                         "saved_to_groups", None
                     )
@@ -1888,7 +1887,11 @@ class AlertWorker:
                     # this should never happen, but just in case
                     log(f"Failed to get all alerts for {alert['objectId']}: {e}")
 
-                self.alert_put_photometry(alert)
+                try:
+                    self.alert_put_photometry(alert)
+                except Exception as e:
+                    traceback.print_exc()
+                    raise e
 
                 # post thumbnails
                 self.alert_post_thumbnails(alert)

--- a/kowalski/alert_brokers/alert_broker.py
+++ b/kowalski/alert_brokers/alert_broker.py
@@ -744,6 +744,10 @@ class AlertWorker:
             df_light_curve["filter"] = df_light_curve["fid"].apply(
                 lambda x: nir_filters[x]
             )
+        elif self.instrument == "TURBO":
+            # the filters are just the fid values
+            # TODO: add the actual filter names
+            df_light_curve["filter"] = df_light_curve["fid"].apply(lambda x: str(x))
 
         df_light_curve["mjd"] = df_light_curve["jd"] - 2400000.5
 
@@ -820,16 +824,9 @@ class AlertWorker:
                 df_fp_hists["filter"] = df_fp_hists["fid"].apply(
                     lambda x: ztf_filters[x]
                 )
-            elif self.instrument == "PGIR":
-                # fixme: PGIR uses 2massj, which is not in sncosmo as of 20210803
-                #        cspjs seems to be close/good enough as an approximation
-                df_light_curve["filter"] = "cspjs"
-            elif self.instrument == "WNTR":
-                # 20220818: added WNTR
-                # 20220929: nir bandpasses have been added to sncosmo
-                nir_filters = {0: "ps1::y", 1: "2massj", 2: "2massh", 3: "2massks"}
-                df_fp_hists["filter"] = df_fp_hists["fid"].apply(
-                    lambda x: nir_filters[x]
+            else:
+                raise NotImplementedError(
+                    f"Processing of forced photometry for {self.instrument} not implemented"
                 )
 
             # add mjd and convert columns to float

--- a/kowalski/alert_brokers/alert_broker_pgir.py
+++ b/kowalski/alert_brokers/alert_broker_pgir.py
@@ -163,7 +163,9 @@ class PGIRAlertConsumer(AlertConsumer, ABC):
                 )
 
             # post to SkyPortal
-            alert_worker.alert_sentinel_skyportal(alert, prv_candidates, passed_filters)
+            alert_worker.alert_sentinel_skyportal(
+                alert, prv_candidates, passed_filters=passed_filters
+            )
 
         # clean up after thyself
         del (

--- a/kowalski/alert_brokers/alert_broker_turbo.py
+++ b/kowalski/alert_brokers/alert_broker_turbo.py
@@ -141,7 +141,9 @@ class TURBOAlertConsumer(AlertConsumer, ABC):
                 )
 
             # post to SkyPortal
-            alert_worker.alert_sentinel_skyportal(alert, prv_candidates, passed_filters)
+            alert_worker.alert_sentinel_skyportal(
+                alert, prv_candidates, passed_filters=passed_filters
+            )
 
         # clean up after thyself
         del (

--- a/kowalski/alert_brokers/alert_broker_winter.py
+++ b/kowalski/alert_brokers/alert_broker_winter.py
@@ -166,7 +166,9 @@ class WNTRAlertConsumer(AlertConsumer, ABC):
                 )
 
             # post to SkyPortal
-            alert_worker.alert_sentinel_skyportal(alert, prv_candidates, passed_filters)
+            alert_worker.alert_sentinel_skyportal(
+                alert, prv_candidates, passed_filters=passed_filters
+            )
 
         # clean up after thyself
         del (

--- a/kowalski/alert_brokers/alert_broker_ztf.py
+++ b/kowalski/alert_brokers/alert_broker_ztf.py
@@ -525,7 +525,7 @@ class ZTFAlertWorker(AlertWorker, ABC):
                         try:
                             response = self.api_skyportal(
                                 "PUT",
-                                f"/api/photometry{'?ignore_flux_deduplication=true&ignore_flux_deduplication_replace=true' if is_fp else ''}",
+                                f"/api/photometry{'?duplicate_ignore_flux=true&overwrite_flux=true' if is_fp else ''}",
                                 photometry,
                                 timeout=15,
                             )

--- a/kowalski/alert_brokers/alert_broker_ztf.py
+++ b/kowalski/alert_brokers/alert_broker_ztf.py
@@ -496,6 +496,9 @@ class ZTFAlertWorker(AlertWorker, ABC):
                 "filter": df_photometry.loc[stream_id_mask, "filter"].tolist(),
                 "ra": df_photometry.loc[stream_id_mask, "ra"].tolist(),
                 "dec": df_photometry.loc[stream_id_mask, "dec"].tolist(),
+                "origin": df_photometry.loc[stream_id_mask, "origin"].tolist()
+                if "origin" in df_photometry
+                else [],
             }
 
             if (len(photometry.get("flux", ())) > 0) or (
@@ -508,7 +511,10 @@ class ZTFAlertWorker(AlertWorker, ABC):
                 ):
                     try:
                         response = self.api_skyportal(
-                            "PUT", "/api/photometry", photometry, timeout=15
+                            "PUT",
+                            "/api/photometry?ignore_flux_deduplication=true&ignore_flux_deduplication_replace=true",
+                            photometry,
+                            timeout=15,
                         )
                         if response.json()["status"] == "success":
                             log(
@@ -540,10 +546,6 @@ class ZTFAlertWorker(AlertWorker, ABC):
         limmag5sig = -2.5 * np.log10(5 * values[1]) + values[2]
         if np.isnan(snr):
             return {}
-        if snr < 0:
-            return {
-                "snr": snr,
-            }
         mag_data = {
             "mag": mag,
             "magerr": magerr,

--- a/kowalski/tests/test_alert_broker_ztf.py
+++ b/kowalski/tests/test_alert_broker_ztf.py
@@ -1015,7 +1015,6 @@ class TestAlertBrokerZTF:
         passed_filters = self.worker.alert_filter__user_defined([filter], record)
 
         assert passed_filters is not None
-        print(passed_filters)
         assert len(passed_filters) == 1
         assert "autosave" in passed_filters[0]
 

--- a/kowalski/tools/init_kafka.py
+++ b/kowalski/tools/init_kafka.py
@@ -20,7 +20,7 @@ def init_kafka():
 
         # check if by any chance the .tar.gz file is already there
         if not Path(f"kafka_{scala_version}-{kafka_version}.tgz").exists():
-            kafka_url = f"https://downloads.apache.org/kafka/{kafka_version}/kafka_{scala_version}-{kafka_version}.tgz"
+            kafka_url = f"https://archive.apache.org/dist/kafka/{kafka_version}/kafka_{scala_version}-{kafka_version}.tgz"
             print(f"Downloading Kafka from {kafka_url}")
 
             r = requests.get(kafka_url)

--- a/requirements/requirements_ingester.txt
+++ b/requirements/requirements_ingester.txt
@@ -30,7 +30,7 @@ PyYAML==6.0
 requests==2.31.0
 slack_sdk==3.20.0
 supervisor==4.2.5
-tables==3.8.0
+tables==3.9.2
 tensorflow==2.13.0
 tqdm==4.64.1
 uvloop==0.17.0


### PR DESCRIPTION
This PR adds the code we need to post forced photometry to Fritz. It uses the new arguments of the photometry PUT handler that allow to not use flux values in deduplication, but only mjd, filter, instrument_id, an origin. That way, even as the flux value at a fixed JD changes for forced photometry, we consider the old and new points as duplicates, and with the 2nd argument we tell SkyPortal to update the flux /fluxerr of said duplicates with the new values.

This shouldn't affect alert-based photometry, which does not change over time anyways. Also, we only update flux and flux values if the duplicate rows have an origin specified, if not we do not update anything (which is the current behavior). So really, this should only affect forced photometry.