### PR TITLE
Ingest Catalogs: get position from existing catalog (by id)

### DIFF
--- a/kowalski/ingesters/ingest_catalog.py
+++ b/kowalski/ingesters/ingest_catalog.py
@@ -54,362 +54,344 @@ def get_mongo_client() -> Mongo:
     raise Exception("Failed to connect to the database after 10 retries")
 
 
-def process_file(argument_list: Sequence):
-    (
-        file,
-        collection,
-        ra_col,
-        dec_col,
-        id_col,
-        batch_size,
-        max_docs,
-        rm,
-        format,
-    ) = argument_list
-
-    log(f"Processing {file}")
-    if format not in ("fits", "csv", "parquet"):
-        log("Format not supported")
-        return
-
-    mongo = get_mongo_client()
-
-    # if the file is not an url
-    if not file.startswith("http"):
-        try:
-            file = pathlib.Path(file).resolve(strict=True)
-        except FileNotFoundError:
-            log(f"File {file} not found")
-            return
-
+def process_fits_file(
+    file,
+    collection,
+    ra_col,
+    dec_col,
+    id_col,
+    position_from_catalog,
+    position_from_catalog_name,
+    position_from_catalog_ra_col,
+    position_from_catalog_dec_col,
+    position_from_catalog_id_col,
+    batch_size,
+    max_docs,
+    mongo,
+):
     total_good_documents = 0
     total_bad_documents = 0
 
-    if format == "fits":
-        names = []
-        with fits.open(file, cache=False) as hdulist:
-            nhdu = 1
-            names = hdulist[nhdu].columns.names
-            dataframe = pd.DataFrame(np.asarray(hdulist[nhdu].data), columns=names)
-            for col in dataframe.columns:
-                if dataframe[col].dtype in [">f4", ">f8"]:
-                    dataframe[col] = dataframe[col].astype(float)
-                elif dataframe[col].dtype in [">i2", ">i4", ">i8"]:
-                    dataframe[col] = dataframe[col].astype(int)
+    names = []
+    with fits.open(file, cache=False) as hdulist:
+        nhdu = 1
+        names = hdulist[nhdu].columns.names
+        dataframe = pd.DataFrame(np.asarray(hdulist[nhdu].data), columns=names)
+        for col in dataframe.columns:
+            if dataframe[col].dtype in [">f4", ">f8"]:
+                dataframe[col] = dataframe[col].astype(float)
+            elif dataframe[col].dtype in [">i2", ">i4", ">i8"]:
+                dataframe[col] = dataframe[col].astype(int)
 
-        if max_docs is not None and isinstance(max_docs, int):
-            dataframe = dataframe.iloc[:max_docs]
+    if max_docs is not None and isinstance(max_docs, int):
+        dataframe = dataframe.iloc[:max_docs]
 
-        if id_col is not None:
-            if id_col not in names:
-                log(f"Provided ID column {id_col} not found")
-                return
-            if dataframe[id_col].isnull().values.any():
-                log(f"ID column {id_col} has null values")
-                return
-            if not isinstance(dataframe[id_col].iloc[0], str):
-                if not isinstance(dataframe[id_col].iloc[0], (int, np.integer)):
-                    log(f"ID column {id_col} is not a string or an integer")
-                    return
-                if dataframe[id_col].iloc[0] < 0:
-                    log(f"ID column {id_col} has negative values")
-                    return
+    if id_col is not None:
+        if id_col not in names:
+            log(f"Provided ID column {id_col} not found")
+            return 0, 0
+        if dataframe[id_col].isnull().values.any():
+            log(f"ID column {id_col} has null values")
+            return 0, 0
+        if not isinstance(dataframe[id_col].iloc[0], str):
+            if not isinstance(dataframe[id_col].iloc[0], (int, np.integer)):
+                log(f"ID column {id_col} is not a string or an integer")
+                return 0, 0
+            if dataframe[id_col].iloc[0] < 0:
+                log(f"ID column {id_col} has negative values")
+                return 0, 0
+
+    if not position_from_catalog and ra_col is None:
+        try:
+            ra_col = [col for col in names if col.lower() in ["ra", "objra"]][0]
+        except IndexError:
+            log("RA column not found")
+            return 0, 0
+    # verify that the columns exist
+    elif not position_from_catalog and ra_col not in names:
+        log(f"Provided RA column {ra_col} not found")
+        return 0, 0
+
+    if not position_from_catalog and dec_col is None:
+        try:
+            dec_col = [col for col in names if col.lower() in ["dec", "objdec"]][0]
+        except IndexError:
+            log("Dec column not found")
+            return 0, 0
+    # verify that the columns exist
+    elif not position_from_catalog and dec_col not in names:
+        log(f"Provided Dec column {dec_col} not found")
+        return 0, 0
+
+    if position_from_catalog:
+        if id_col is None:
+            log(
+                "No ID column (in the catalog to ingest) provided to get positions from"
+            )
+            return 0, 0
+        if position_from_catalog_name is None:
+            log("No catalog name provided to get positions from")
+            return 0, 0
+        if position_from_catalog_ra_col is None:
+            log("No RA column provided to get positions from")
+            return 0, 0
+        if position_from_catalog_dec_col is None:
+            log("No Dec column provided to get positions from")
+            return 0, 0
+        if position_from_catalog_id_col is None:
+            log("No ID column provided to get positions from")
+            return 0, 0
+        if position_from_catalog_name == collection:
+            log("Cannot get positions from the same collection")
+            return 0, 0
 
         if ra_col is None:
-            try:
-                ra_col = [col for col in names if col.lower() in ["ra", "objra"]][0]
-            except IndexError:
-                log("RA column not found")
-                return
-        else:
-            # verify that the columns exist
-            if ra_col not in names:
-                log(f"Provided RA column {ra_col} not found")
-                return
-
+            ra_col = "ra"
         if dec_col is None:
-            try:
-                dec_col = [col for col in names if col.lower() in ["dec", "objdec"]][0]
-            except IndexError:
-                log("Dec column not found")
-                return
-        else:
-            # verify that the columns exist
-            if dec_col not in names:
-                log(f"Provided Dec column {dec_col} not found")
-                return
+            dec_col = "dec"
 
-        for chunk_index, dataframe_chunk in dataframe.groupby(
-            np.arange(len(dataframe)) // batch_size
-        ):
+    for chunk_index, dataframe_chunk in dataframe.groupby(
+        np.arange(len(dataframe)) // batch_size
+    ):
 
-            for col, dtype in dataframe_chunk.dtypes.items():
-                if dtype == object:
-                    dataframe_chunk[col] = dataframe_chunk[col].apply(
-                        lambda x: x.decode("utf-8")
-                    )
+        for col, dtype in dataframe_chunk.dtypes.items():
+            if dtype == object:
+                dataframe_chunk[col] = dataframe_chunk[col].apply(
+                    lambda x: x.decode("utf-8")
+                )
 
-            batch = dataframe_chunk.to_dict(orient="records")
-            batch = dataframe_chunk.fillna("DROPMEPLEASE").to_dict(orient="records")
+        batch = dataframe_chunk.to_dict(orient="records")
+        batch = dataframe_chunk.fillna("DROPMEPLEASE").to_dict(orient="records")
 
-            # pop nulls - save space
-            batch = [
-                {
-                    key: value
-                    for key, value in document.items()
-                    if value != "DROPMEPLEASE"
-                }
-                for document in batch
-            ]
-
-            if id_col is not None:
-                for document in batch:
-                    if id_col not in document.keys():
-                        log(f"Provided ID column {id_col} not found")
-                        return
-                    document["_id"] = document.pop(id_col)
-
-            bad_document_indexes = []
-
-            for document_index, document in enumerate(batch):
-                try:
-                    # GeoJSON for 2D indexing
-                    document["coordinates"] = dict()
-                    # string format: H:M:S, D:M:S
-                    if document[ra_col] == 360.0:
-                        document[ra_col] = 0.0
-                    document["coordinates"]["radec_str"] = [
-                        deg2hms(document[ra_col]),
-                        deg2dms(document[dec_col]),
-                    ]
-                    # for GeoJSON, must be lon:[-180, 180], lat:[-90, 90] (i.e. in deg)
-                    _radec_geojson = [document[ra_col] - 180.0, document[dec_col]]
-                    document["coordinates"]["radec_geojson"] = {
-                        "type": "Point",
-                        "coordinates": _radec_geojson,
-                    }
-
-                    # if the entry is a string, strip it
-                    # if it ends up being an empty string, it will be dropped
-                    keys_to_pop = []
-                    for key, value in document.items():
-                        if isinstance(value, str):
-                            document[key] = value.strip()
-                            if not document[key] or len(document[key]) == 0:
-                                keys_to_pop.append(key)
-                    for key in keys_to_pop:
-                        document.pop(key)
-                except Exception as e:
-                    log(str(e))
-                    bad_document_indexes.append(document_index)
-
-            total_good_documents += len(batch) - len(bad_document_indexes)
-            if len(bad_document_indexes) > 0:
-                total_bad_documents += len(bad_document_indexes)
-                for index in sorted(bad_document_indexes, reverse=True):
-                    del batch[index]
-
-            # ingest batch
-            mongo.insert_many(collection=collection, documents=batch)
-
-    elif format == "csv":
-        last_chunk = False
-        for chunk_index, dataframe_chunk in enumerate(
-            pd.read_csv(file, chunksize=batch_size)
-        ):
-            if last_chunk:
-                break
-            if max_docs is not None and isinstance(max_docs, int):
-                if (chunk_index + 1) * batch_size > max_docs:
-                    dataframe_chunk = dataframe_chunk.iloc[: max_docs % batch_size]
-                    last_chunk = True
-
-            names = list(dataframe_chunk.columns)
-
-            if id_col is not None:
-                if id_col not in names:
-                    log(f"Provided ID column {id_col} not found")
-                    return
-                # if there is any row where this is None, return
-                if dataframe_chunk[id_col].isnull().values.any():
-                    log(f"ID column {id_col} has null values")
-                    return
-                if not isinstance(dataframe_chunk[id_col].iloc[0], str):
-                    if not isinstance(
-                        dataframe_chunk[id_col].iloc[0], (int, np.integer)
-                    ):
-                        log(f"ID column {id_col} is not a string or an integer")
-                        return
-                    if dataframe_chunk[id_col].iloc[0] < 0:
-                        log(f"ID column {id_col} has negative values")
-                        return
-
-            if ra_col is None:
-                try:
-                    ra_col = [col for col in names if col.lower() in ["ra", "objra"]][0]
-                except IndexError:
-                    log("No RA column found")
-                    return
-            else:
-                # verify that the columns exist
-                if ra_col not in names:
-                    log(f"Provided RA column {ra_col} not found")
-                    return
-
-            if dec_col is None:
-                try:
-                    dec_col = [
-                        col for col in names if col.lower() in ["dec", "objdec"]
-                    ][0]
-                except IndexError:
-                    log("No Dec column found")
-                    return
-            else:
-                # verify that the columns exist
-                if dec_col not in names:
-                    log(f"Provided Dec column {dec_col} not found")
-                    return
-
-            batch = dataframe_chunk.to_dict(orient="records")
-
-            if id_col is not None:
-                for document in batch:
-                    if id_col not in document.keys():
-                        log(f"Provided ID column {id_col} not found")
-                        return
-                    document["_id"] = document.pop(id_col)
-
-            bad_document_indexes = []
-
-            for document_index, document in enumerate(batch):
-                try:
-                    # GeoJSON for 2D indexing
-                    document["coordinates"] = dict()
-                    # string format: H:M:S, D:M:S
-                    document["coordinates"]["radec_str"] = [
-                        deg2hms(document[ra_col]),
-                        deg2dms(document[dec_col]),
-                    ]
-                    # for GeoJSON, must be lon:[-180, 180], lat:[-90, 90] (i.e. in deg)
-                    _radec_geojson = [document[ra_col] - 180.0, document[dec_col]]
-                    document["coordinates"]["radec_geojson"] = {
-                        "type": "Point",
-                        "coordinates": _radec_geojson,
-                    }
-                except Exception as e:
-                    log(str(e))
-                    bad_document_indexes.append(document_index)
-
-            total_good_documents += len(batch) - len(bad_document_indexes)
-            if len(bad_document_indexes) > 0:
-                total_bad_documents += len(bad_document_indexes)
-                for index in sorted(bad_document_indexes, reverse=True):
-                    del batch[index]
-
-            # ingest batch
-            mongo.insert_many(collection=collection, documents=batch)
-
-    elif format == "parquet":
-        df: pd.DataFrame = pq.read_table(file).to_pandas()
-        for name in list(df.columns):
-            if name.startswith("_"):
-                df.rename(columns={name: name[1:]}, inplace=True)
-        names = list(df.columns)
+        # pop nulls - save space
+        batch = [
+            {key: value for key, value in document.items() if value != "DROPMEPLEASE"}
+            for document in batch
+        ]
 
         if id_col is not None:
-            if id_col.startswith("_"):
-                id_col = id_col[1:]
+            for document in batch:
+                if id_col not in document.keys():
+                    log(f"Provided ID column {id_col} not found")
+                    return 0, 0
+                document["_id"] = document.pop(id_col)
+
+        bad_document_indexes = []
+
+        for document_index, document in enumerate(batch):
+            try:
+                if position_from_catalog:
+                    # get position from other catalog (by id) if the catalog to ingest does not have it
+                    try:
+                        position = mongo.db[position_from_catalog_name].find_one(
+                            filter={position_from_catalog_id_col: document["_id"]},
+                            projection={
+                                position_from_catalog_ra_col: 1,
+                                position_from_catalog_dec_col: 1,
+                                "_id": 0,
+                            },
+                        )
+                        if position is not None and {
+                            position_from_catalog_ra_col,
+                            position_from_catalog_dec_col,
+                        }.issubset(position.keys()):
+                            document[ra_col] = position[position_from_catalog_ra_col]
+                            document[dec_col] = position[position_from_catalog_dec_col]
+                        else:
+                            log(
+                                f"Failed to get position for {document['_id']} from {position_from_catalog_name} (with {position_from_catalog_id_col} {id_col} {ra_col} {dec_col})"
+                            )
+                            bad_document_indexes.append(document_index)
+                            continue
+                    except Exception as e:
+                        log(
+                            f"Failed to get position for {document['_id']} from {position_from_catalog_name} (with {position_from_catalog_id_col} {id_col} {ra_col} {dec_col}): {str(e)}"
+                        )
+                        bad_document_indexes.append(document_index)
+                        continue
+                # GeoJSON for 2D indexing
+                document["coordinates"] = dict()
+                # string format: H:M:S, D:M:S
+                if document[ra_col] == 360.0:
+                    document[ra_col] = 0.0
+                document["coordinates"]["radec_str"] = [
+                    deg2hms(document[ra_col]),
+                    deg2dms(document[dec_col]),
+                ]
+                # for GeoJSON, must be lon:[-180, 180], lat:[-90, 90] (i.e. in deg)
+                _radec_geojson = [document[ra_col] - 180.0, document[dec_col]]
+                document["coordinates"]["radec_geojson"] = {
+                    "type": "Point",
+                    "coordinates": _radec_geojson,
+                }
+
+                # if the entry is a string, strip it
+                # if it ends up being an empty string, it will be dropped
+                keys_to_pop = []
+                for key, value in document.items():
+                    if isinstance(value, str):
+                        document[key] = value.strip()
+                        if not document[key] or len(document[key]) == 0:
+                            keys_to_pop.append(key)
+                for key in keys_to_pop:
+                    document.pop(key)
+            except Exception as e:
+                traceback.print_exc()
+                log(f"Failed to process document {document_index}: {str(e)}")
+                bad_document_indexes.append(document_index)
+
+        total_good_documents += len(batch) - len(bad_document_indexes)
+        if len(bad_document_indexes) > 0:
+            total_bad_documents += len(bad_document_indexes)
+            for index in sorted(bad_document_indexes, reverse=True):
+                del batch[index]
+
+        # ingest batch
+        mongo.insert_many(collection=collection, documents=batch)
+
+    return total_good_documents, total_bad_documents
+
+
+def process_csv_file(
+    file,
+    collection,
+    ra_col,
+    dec_col,
+    id_col,
+    position_from_catalog,
+    position_from_catalog_name,
+    position_from_catalog_ra_col,
+    position_from_catalog_dec_col,
+    position_from_catalog_id_col,
+    batch_size,
+    max_docs,
+    mongo,
+):
+    total_good_documents = 0
+    total_bad_documents = 0
+
+    last_chunk = False
+    for chunk_index, dataframe_chunk in enumerate(
+        pd.read_csv(file, chunksize=batch_size)
+    ):
+        if last_chunk:
+            break
+        if max_docs is not None and isinstance(max_docs, int):
+            if (chunk_index + 1) * batch_size > max_docs:
+                dataframe_chunk = dataframe_chunk.iloc[: max_docs % batch_size]
+                last_chunk = True
+
+        names = list(dataframe_chunk.columns)
+
+        if id_col is not None:
             if id_col not in names:
                 log(f"Provided ID column {id_col} not found")
-                return
+                return 0, 0
             # if there is any row where this is None, return
-            if df[id_col].isnull().values.any():
+            if dataframe_chunk[id_col].isnull().values.any():
                 log(f"ID column {id_col} has null values")
-                return
-            if not isinstance(df[id_col].iloc[0], str):
-                if not isinstance(df[id_col].iloc[0], (int, np.integer)):
+                return 0, 0
+            if not isinstance(dataframe_chunk[id_col].iloc[0], str):
+                if not isinstance(dataframe_chunk[id_col].iloc[0], (int, np.integer)):
                     log(f"ID column {id_col} is not a string or an integer")
-                    return
-                if df[id_col].iloc[0] < 0:
+                    return 0, 0
+                if dataframe_chunk[id_col].iloc[0] < 0:
                     log(f"ID column {id_col} has negative values")
-                    return
-        if ra_col is None:
+                    return 0, 0
+
+        if not position_from_catalog and ra_col is None:
             try:
                 ra_col = [col for col in names if col.lower() in ["ra", "objra"]][0]
             except IndexError:
                 log("No RA column found")
-                return
-        else:
+                return 0, 0
+        elif not position_from_catalog and ra_col not in names:
             # verify that the columns exist
             if ra_col not in names:
                 log(f"Provided RA column {ra_col} not found")
-                return
+                return 0, 0
 
-        if dec_col is None:
+        if not position_from_catalog and dec_col is None:
             try:
                 dec_col = [col for col in names if col.lower() in ["dec", "objdec"]][0]
             except IndexError:
                 log("No Dec column found")
-                return
-        else:
+                return 0, 0
+        elif not position_from_catalog and dec_col not in names:
             # verify that the columns exist
             if dec_col not in names:
-                log(f"Provided DEC column {dec_col} not found")
-                return
+                log(f"Provided Dec column {dec_col} not found")
+                return 0, 0
 
-        batch = []
+        if position_from_catalog:
+            if id_col is None:
+                log(
+                    "No ID column (in the catalog to ingest) provided to get positions from"
+                )
+                return 0, 0
+            if position_from_catalog_name is None:
+                log("No catalog name provided to get positions from")
+                return 0, 0
+            if position_from_catalog_ra_col is None:
+                log("No RA column provided to get positions from")
+                return 0, 0
+            if position_from_catalog_dec_col is None:
+                log("No Dec column provided to get positions from")
+                return 0, 0
+            if position_from_catalog_id_col is None:
+                log("No ID column provided to get positions from")
+                return 0, 0
+            if position_from_catalog_name == collection:
+                log("Cannot get positions from the same collection")
+                return 0, 0
 
-        def convert_nparray_to_list(value):
-            if isinstance(value, np.ndarray):
-                return [convert_nparray_to_list(v) for v in value]
-            elif isinstance(value, np.integer):
-                return int(value)
-            elif isinstance(value, np.floating):
-                return float(value)
-            elif isinstance(value, np.bool_):
-                return bool(value)
-            elif pd.isna(value):
-                return None
-            else:
-                return value
+            if ra_col is None:
+                ra_col = "ra"
+            if dec_col is None:
+                dec_col = "dec"
 
-        for row in df.itertuples():
-            if max_docs and total_good_documents + total_bad_documents >= max_docs:
-                break
+        batch = dataframe_chunk.to_dict(orient="records")
+
+        if id_col is not None:
+            for document in batch:
+                if id_col not in document.keys():
+                    log(f"Provided ID column {id_col} not found")
+                    return 0, 0
+                document["_id"] = document.pop(id_col)
+
+        bad_document_indexes = []
+
+        for document_index, document in enumerate(batch):
             try:
-                document = {}
-                # drop any value with NAType
-                for k, v in row._asdict().items():
-                    if k == "Index":
+                if position_from_catalog:
+                    # get position from other catalog (by id) if the catalog to ingest does not have it
+                    try:
+                        position = mongo.db[position_from_catalog_name].find_one(
+                            filter={position_from_catalog_id_col: document["_id"]},
+                            projection={
+                                position_from_catalog_ra_col: 1,
+                                position_from_catalog_dec_col: 1,
+                                "_id": 0,
+                            },
+                        )
+                        if position is not None and {
+                            position_from_catalog_ra_col,
+                            position_from_catalog_dec_col,
+                        }.issubset(position.keys()):
+                            document[ra_col] = position[position_from_catalog_ra_col]
+                            document[dec_col] = position[position_from_catalog_dec_col]
+                        else:
+                            log(
+                                f"Failed to get position for {document['_id']} from {position_from_catalog_name} (with {position_from_catalog_id_col} {id_col} {ra_col} {dec_col})"
+                            )
+                            bad_document_indexes.append(document_index)
+                            continue
+                    except Exception as e:
+                        log(
+                            f"Failed to get position for {document['_id']} from {position_from_catalog_name} (with {position_from_catalog_id_col} {id_col} {ra_col} {dec_col}): {str(e)}"
+                        )
+                        bad_document_indexes.append(document_index)
                         continue
-                    if isinstance(v, (pd.core.series.Series, np.ndarray)):
-                        # recursively convert np arrays and series to lists
-                        try:
-                            document[k] = convert_nparray_to_list(v)
-                        except Exception as e:
-                            log(f"Failed to convert {k} to list: {str(e)}")
-                    # if its a numerical type other than the python ones (like np.int64), convert to python type
-                    elif isinstance(v, np.integer):
-                        document[k] = int(v)
-                    elif isinstance(v, np.floating):
-                        document[k] = float(v)
-                    elif isinstance(v, np.bool_):
-                        document[k] = bool(v)
-                    elif pd.isna(v):
-                        document[k] = None
-                    else:
-                        document[k] = v
-
-                if id_col is not None:
-                    if id_col not in document.keys():
-                        log(f"Provided ID column {id_col} not found")
-                        return
-                    document["_id"] = document.pop(id_col)
-
-                # if there is already a key called radec_geojson, then delete it
-                if "radec_geojson" in document.keys():
-                    del document["radec_geojson"]
-
                 # GeoJSON for 2D indexing
                 document["coordinates"] = dict()
                 # string format: H:M:S, D:M:S
@@ -423,55 +405,224 @@ def process_file(argument_list: Sequence):
                     "type": "Point",
                     "coordinates": _radec_geojson,
                 }
-                batch.append(document)
-            except Exception as exception:
-                total_bad_documents += 1
-                log(str(exception))
-                continue
-
-            # ingest in batches
-            try:
-                if (len(batch) % batch_size == 0 and len(batch) != 0) or len(
-                    batch
-                ) == max_docs:
-                    n_retries = 0
-                    while n_retries < 10:
-                        mongo.insert_many(
-                            collection=collection,
-                            documents=batch,
-                        )
-                        if id_col is not None:
-                            ids = [doc["_id"] for doc in batch]
-                            count = mongo.db[collection].count_documents(
-                                {"_id": {"$in": ids}}
-                            )
-                            if count == len(batch):
-                                total_good_documents += len(batch)
-                                break
-                            n_retries += 1
-                            time.sleep(6)
-                            mongo.close()
-                            mongo = get_mongo_client()
-                        else:
-                            total_good_documents += len(batch)
-                            break
-
-                    if n_retries == 10:
-                        log(
-                            f"Failed to ingest batch for {file} after {n_retries} retries, skipping"
-                        )
-                        total_bad_documents += len(batch)
-
-                    # flush:
-                    batch = []
             except Exception as e:
                 log(str(e))
+                bad_document_indexes.append(document_index)
 
-        while len(batch) > 0:
-            try:
+        total_good_documents += len(batch) - len(bad_document_indexes)
+        if len(bad_document_indexes) > 0:
+            total_bad_documents += len(bad_document_indexes)
+            for index in sorted(bad_document_indexes, reverse=True):
+                del batch[index]
+
+        # ingest batch
+        mongo.insert_many(collection=collection, documents=batch)
+
+
+def process_parquet_file(
+    file,
+    collection,
+    ra_col,
+    dec_col,
+    id_col,
+    position_from_catalog,
+    position_from_catalog_name,
+    position_from_catalog_ra_col,
+    position_from_catalog_dec_col,
+    position_from_catalog_id_col,
+    batch_size,
+    max_docs,
+    mongo,
+):
+    total_good_documents = 0
+    total_bad_documents = 0
+
+    df: pd.DataFrame = pq.read_table(file).to_pandas()
+    for name in list(df.columns):
+        if name.startswith("_"):
+            df.rename(columns={name: name[1:]}, inplace=True)
+    names = list(df.columns)
+
+    if id_col is not None:
+        if id_col.startswith("_"):
+            id_col = id_col[1:]
+        if id_col not in names:
+            log(f"Provided ID column {id_col} not found")
+            return 0, 0
+        # if there is any row where this is None, return
+        if df[id_col].isnull().values.any():
+            log(f"ID column {id_col} has null values")
+            return 0, 0
+        if not isinstance(df[id_col].iloc[0], str):
+            if not isinstance(df[id_col].iloc[0], (int, np.integer)):
+                log(f"ID column {id_col} is not a string or an integer")
+                return 0, 0
+            if df[id_col].iloc[0] < 0:
+                log(f"ID column {id_col} has negative values")
+                return 0, 0
+
+    if not position_from_catalog and ra_col is None:
+        try:
+            ra_col = [col for col in names if col.lower() in ["ra", "objra"]][0]
+        except IndexError:
+            log("No RA column found")
+            return 0, 0
+    elif not position_from_catalog and ra_col not in names:
+        # verify that the columns exist
+        if ra_col not in names:
+            log(f"Provided RA column {ra_col} not found")
+            return 0, 0
+
+    if not position_from_catalog and dec_col is None:
+        try:
+            dec_col = [col for col in names if col.lower() in ["dec", "objdec"]][0]
+        except IndexError:
+            log("No Dec column found")
+            return 0, 0
+    elif not position_from_catalog and dec_col not in names:
+        # verify that the columns exist
+        if dec_col not in names:
+            log(f"Provided DEC column {dec_col} not found")
+            return 0, 0
+
+    if position_from_catalog:
+        if id_col is None:
+            log(
+                "No ID column (in the catalog to ingest) provided to get positions from"
+            )
+            return 0, 0
+        if position_from_catalog_name is None:
+            log("No catalog name provided to get positions from")
+            return 0, 0
+        if position_from_catalog_ra_col is None:
+            log("No RA column provided to get positions from")
+            return 0, 0
+        if position_from_catalog_dec_col is None:
+            log("No Dec column provided to get positions from")
+            return 0, 0
+        if position_from_catalog_id_col is None:
+            log("No ID column provided to get positions from")
+            return 0, 0
+        if position_from_catalog_name == collection:
+            log("Cannot get positions from the same collection")
+            return 0, 0
+
+        if ra_col is None:
+            ra_col = "ra"
+        if dec_col is None:
+            dec_col = "dec"
+
+    batch = []
+
+    def convert_nparray_to_list(value):
+        if isinstance(value, np.ndarray):
+            return [convert_nparray_to_list(v) for v in value]
+        elif isinstance(value, np.integer):
+            return int(value)
+        elif isinstance(value, np.floating):
+            return float(value)
+        elif isinstance(value, np.bool_):
+            return bool(value)
+        elif pd.isna(value):
+            return None
+        else:
+            return value
+
+    for row in df.itertuples():
+        if max_docs and total_good_documents + total_bad_documents >= max_docs:
+            break
+        try:
+            document = {}
+            # drop any value with NAType
+            for k, v in row._asdict().items():
+                if k == "Index":
+                    continue
+                if isinstance(v, (pd.core.series.Series, np.ndarray)):
+                    # recursively convert np arrays and series to lists
+                    try:
+                        document[k] = convert_nparray_to_list(v)
+                    except Exception as e:
+                        log(f"Failed to convert {k} to list: {str(e)}")
+                # if its a numerical type other than the python ones (like np.int64), convert to python type
+                elif isinstance(v, np.integer):
+                    document[k] = int(v)
+                elif isinstance(v, np.floating):
+                    document[k] = float(v)
+                elif isinstance(v, np.bool_):
+                    document[k] = bool(v)
+                elif pd.isna(v):
+                    document[k] = None
+                else:
+                    document[k] = v
+
+            if id_col is not None:
+                if id_col not in document.keys():
+                    log(f"Provided ID column {id_col} not found")
+                    return total_good_documents, total_bad_documents
+                document["_id"] = document.pop(id_col)
+
+            # if there is already a key called radec_geojson, then delete it
+            if "radec_geojson" in document.keys():
+                del document["radec_geojson"]
+
+            if position_from_catalog:
+                # get position from other catalog (by id) if the catalog to ingest does not have it
+                try:
+                    position = mongo.db[position_from_catalog_name].find_one(
+                        filter={position_from_catalog_id_col: document["_id"]},
+                        projection={
+                            position_from_catalog_ra_col: 1,
+                            position_from_catalog_dec_col: 1,
+                            "_id": 0,
+                        },
+                    )
+                    if position is not None and {
+                        position_from_catalog_ra_col,
+                        position_from_catalog_dec_col,
+                    }.issubset(position.keys()):
+                        document[ra_col] = position[position_from_catalog_ra_col]
+                        document[dec_col] = position[position_from_catalog_dec_col]
+                    else:
+                        log(
+                            f"Failed to get position for {document['_id']} from {position_from_catalog_name} (with {position_from_catalog_id_col} {id_col} {ra_col} {dec_col})"
+                        )
+                        continue
+                except Exception as e:
+                    log(
+                        f"Failed to get position for {document['_id']} from {position_from_catalog_name} (with {position_from_catalog_id_col} {id_col} {ra_col} {dec_col}): {str(e)}"
+                    )
+                    continue
+
+            # GeoJSON for 2D indexing
+            document["coordinates"] = dict()
+            # string format: H:M:S, D:M:S
+            document["coordinates"]["radec_str"] = [
+                deg2hms(document[ra_col]),
+                deg2dms(document[dec_col]),
+            ]
+            # for GeoJSON, must be lon:[-180, 180], lat:[-90, 90] (i.e. in deg)
+            _radec_geojson = [document[ra_col] - 180.0, document[dec_col]]
+            document["coordinates"]["radec_geojson"] = {
+                "type": "Point",
+                "coordinates": _radec_geojson,
+            }
+            batch.append(document)
+        except Exception as exception:
+            total_bad_documents += 1
+            log(str(exception))
+            continue
+
+        # ingest in batches
+        try:
+            if (len(batch) % batch_size == 0 and len(batch) != 0) or len(
+                batch
+            ) == max_docs:
                 n_retries = 0
                 while n_retries < 10:
-                    mongo.insert_many(collection=collection, documents=batch)
+                    mongo.insert_many(
+                        collection=collection,
+                        documents=batch,
+                    )
                     if id_col is not None:
                         ids = [doc["_id"] for doc in batch]
                         count = mongo.db[collection].count_documents(
@@ -490,19 +641,133 @@ def process_file(argument_list: Sequence):
 
                 if n_retries == 10:
                     log(
-                        f"Failed to ingest batch for {file} after {n_retries} retries, skipping and not deleting file"
+                        f"Failed to ingest batch for {file} after {n_retries} retries, skipping"
                     )
                     total_bad_documents += len(batch)
-                    rm = False
+
                 # flush:
                 batch = []
-            except Exception as e:
-                log(str(e))
-                log("Failed, waiting 6 seconds to retry")
-                time.sleep(6)
-                mongo.close()
-                mongo = get_mongo_client()
+        except Exception as e:
+            log(str(e))
 
+    while len(batch) > 0:
+        try:
+            n_retries = 0
+            while n_retries < 10:
+                mongo.insert_many(collection=collection, documents=batch)
+                if id_col is not None:
+                    ids = [doc["_id"] for doc in batch]
+                    count = mongo.db[collection].count_documents({"_id": {"$in": ids}})
+                    if count == len(batch):
+                        total_good_documents += len(batch)
+                        break
+                    n_retries += 1
+                    time.sleep(6)
+                    mongo.close()
+                    mongo = get_mongo_client()
+                else:
+                    total_good_documents += len(batch)
+                    break
+
+            if n_retries == 10:
+                log(
+                    f"Failed to ingest batch for {file} after {n_retries} retries, skipping and not deleting file"
+                )
+                total_bad_documents += len(batch)
+            # flush:
+            batch = []
+        except Exception as e:
+            log(str(e))
+            log("Failed, waiting 6 seconds to retry")
+            time.sleep(6)
+            mongo.close()
+            mongo = get_mongo_client()
+
+
+def process_file(argument_list: Sequence):
+    (
+        file,
+        collection,
+        ra_col,
+        dec_col,
+        id_col,
+        position_from_catalog,
+        position_from_catalog_name,
+        position_from_catalog_ra_col,
+        position_from_catalog_dec_col,
+        position_from_catalog_id_col,
+        batch_size,
+        max_docs,
+        rm,
+        format,
+    ) = argument_list
+
+    log(f"Processing {file}")
+    if format not in ("fits", "csv", "parquet"):
+        log("Format not supported")
+        return 0, 0
+
+    mongo = get_mongo_client()
+
+    # if the file is not an url
+    if not file.startswith("http"):
+        try:
+            file = pathlib.Path(file).resolve(strict=True)
+        except FileNotFoundError:
+            log(f"File {file} not found")
+            return 0, 0
+
+    total_good_documents = 0
+    total_bad_documents = 0
+
+    if format == "fits":
+        total_good_documents, total_bad_documents = process_fits_file(
+            file,
+            collection,
+            ra_col,
+            dec_col,
+            id_col,
+            position_from_catalog,
+            position_from_catalog_name,
+            position_from_catalog_ra_col,
+            position_from_catalog_dec_col,
+            position_from_catalog_id_col,
+            batch_size,
+            max_docs,
+            mongo,
+        )
+    elif format == "csv":
+        total_good_documents, total_bad_documents = process_csv_file(
+            file,
+            collection,
+            ra_col,
+            dec_col,
+            id_col,
+            position_from_catalog,
+            position_from_catalog_name,
+            position_from_catalog_ra_col,
+            position_from_catalog_dec_col,
+            position_from_catalog_id_col,
+            batch_size,
+            max_docs,
+            mongo,
+        )
+    elif format == "parquet":
+        total_good_documents, total_bad_documents = process_parquet_file(
+            file,
+            collection,
+            ra_col,
+            dec_col,
+            id_col,
+            position_from_catalog,
+            position_from_catalog_name,
+            position_from_catalog_ra_col,
+            position_from_catalog_dec_col,
+            position_from_catalog_id_col,
+            batch_size,
+            max_docs,
+            mongo,
+        )
     else:
         log("Unknown format. Supported formats: fits, csv, parquet")
         return 0, 0
@@ -517,7 +782,7 @@ def process_file(argument_list: Sequence):
     if total_bad_documents > 0:
         log(f"Failed to ingest {total_bad_documents} documents")
 
-    if total_bad_documents == 0 and rm is True:
+    if total_bad_documents == 0 and total_good_documents > 0 and rm is True:
         try:
             os.remove(pathlib.Path(file))
         except Exception as e:
@@ -620,6 +885,11 @@ def run(
     format: str = "fits",
     verify_only: bool = False,
     skip_verify: bool = False,
+    position_from_catalog: bool = False,
+    position_from_catalog_name: str = None,
+    position_from_catalog_ra_col: str = None,
+    position_from_catalog_dec_col: str = None,
+    position_from_catalog_id_col: str = None,
 ):
     """Pre-process and ingest catalog from fits files into Kowalski
     :param path: path to fits file
@@ -667,6 +937,11 @@ def run(
             ra_col,
             dec_col,
             id_col,
+            position_from_catalog,
+            position_from_catalog_name,
+            position_from_catalog_ra_col,
+            position_from_catalog_dec_col,
+            position_from_catalog_id_col,
             batch_size,
             max_docs,
             rm,

--- a/kowalski/ingesters/ingest_catalog.py
+++ b/kowalski/ingesters/ingest_catalog.py
@@ -418,6 +418,8 @@ def process_csv_file(
         # ingest batch
         mongo.insert_many(collection=collection, documents=batch)
 
+        return total_good_documents, total_bad_documents
+
 
 def process_parquet_file(
     file,
@@ -683,6 +685,8 @@ def process_parquet_file(
             mongo.close()
             mongo = get_mongo_client()
 
+    return total_good_documents, total_bad_documents
+
 
 def process_file(argument_list: Sequence):
     (
@@ -721,53 +725,65 @@ def process_file(argument_list: Sequence):
     total_bad_documents = 0
 
     if format == "fits":
-        total_good_documents, total_bad_documents = process_fits_file(
-            file,
-            collection,
-            ra_col,
-            dec_col,
-            id_col,
-            position_from_catalog,
-            position_from_catalog_name,
-            position_from_catalog_ra_col,
-            position_from_catalog_dec_col,
-            position_from_catalog_id_col,
-            batch_size,
-            max_docs,
-            mongo,
-        )
+        try:
+            total_good_documents, total_bad_documents = process_fits_file(
+                file,
+                collection,
+                ra_col,
+                dec_col,
+                id_col,
+                position_from_catalog,
+                position_from_catalog_name,
+                position_from_catalog_ra_col,
+                position_from_catalog_dec_col,
+                position_from_catalog_id_col,
+                batch_size,
+                max_docs,
+                mongo,
+            )
+        except Exception as e:
+            traceback.print_exc()
+            log(f"Failed to process fits: {e}")
     elif format == "csv":
-        total_good_documents, total_bad_documents = process_csv_file(
-            file,
-            collection,
-            ra_col,
-            dec_col,
-            id_col,
-            position_from_catalog,
-            position_from_catalog_name,
-            position_from_catalog_ra_col,
-            position_from_catalog_dec_col,
-            position_from_catalog_id_col,
-            batch_size,
-            max_docs,
-            mongo,
-        )
+        try:
+            total_good_documents, total_bad_documents = process_csv_file(
+                file,
+                collection,
+                ra_col,
+                dec_col,
+                id_col,
+                position_from_catalog,
+                position_from_catalog_name,
+                position_from_catalog_ra_col,
+                position_from_catalog_dec_col,
+                position_from_catalog_id_col,
+                batch_size,
+                max_docs,
+                mongo,
+            )
+        except Exception as e:
+            traceback.print_exc()
+            log(f"Failed to process csv: {e}")
     elif format == "parquet":
-        total_good_documents, total_bad_documents = process_parquet_file(
-            file,
-            collection,
-            ra_col,
-            dec_col,
-            id_col,
-            position_from_catalog,
-            position_from_catalog_name,
-            position_from_catalog_ra_col,
-            position_from_catalog_dec_col,
-            position_from_catalog_id_col,
-            batch_size,
-            max_docs,
-            mongo,
-        )
+        try:
+            total_good_documents, total_bad_documents = process_parquet_file(
+                file,
+                collection,
+                ra_col,
+                dec_col,
+                id_col,
+                position_from_catalog,
+                position_from_catalog_name,
+                position_from_catalog_ra_col,
+                position_from_catalog_dec_col,
+                position_from_catalog_id_col,
+                batch_size,
+                max_docs,
+                mongo,
+            )
+        except Exception as e:
+            traceback.print_exc()
+            log(f"Failed to process parquet: {e}")
     else:
         log("Unknown format. Supported formats: fits, csv, parquet")
         return 0, 0

--- a/kowalski/tools/fetch_ps1_psc.py
+++ b/kowalski/tools/fetch_ps1_psc.py
@@ -1,0 +1,126 @@
+from bs4 import BeautifulSoup
+import fire
+import multiprocessing as mp
+import pathlib
+import requests
+import subprocess
+from tqdm import tqdm
+from typing import Sequence
+from urllib.parse import urljoin
+import time
+from astropy.io import fits
+
+from kowalski.log import log
+
+
+def collect_urls() -> list:
+    """Collect URLs of all the individual FITS files for the PS1 PSC dataset
+
+    https://archive.stsci.edu/hlsps/ps1-psc/
+
+    :return:
+    """
+    base_url: str = "https://archive.stsci.edu/hlsps/ps1-psc/"
+
+    response = requests.get(
+        base_url,
+    )
+    html = response.text
+
+    soup = BeautifulSoup(html, "html.parser")
+    links = soup.findAll("a")
+    # remove the a which href does not start with <a href="hlsp_ps1-psc_ps1_gpc
+    links = [
+        link
+        for link in links
+        if link.get("href").startswith("hlsp_ps1-psc_ps1_gpc")
+        and link.get("href").endswith(".fits")
+    ]
+
+    link_list = []
+
+    for link in links:
+        link_list.append({"name": link, "url": urljoin(base_url, link.get("href"))})
+
+    return link_list
+
+
+def fetch_url(argument_list: Sequence):
+    """Download a file from a URL"""
+    # unpack arguments
+    base_path, url = argument_list
+
+    path = base_path / pathlib.Path(url).name
+    n_retries = 0
+    while n_retries < 5:
+        if not path.exists():
+            try:
+                subprocess.run(
+                    [
+                        "wget",
+                        "-O",
+                        str(path),
+                        url,
+                    ]
+                )
+            except Exception as e:
+                log(f"Exception while downloading {url}: {e}, redownloading")
+                # remove the file if it exists
+                if path.exists():
+                    subprocess.run(["rm", "-f", str(path)])
+                n_retries += 1
+                time.sleep(10)
+                continue
+        # try to open the file and read the header and first row
+        try:
+            with fits.open(path) as hdul:
+                _ = hdul[0].header
+                log(f"Downloaded and validated {url} to {path}")
+            break
+        except Exception as e:
+            log(f"Exception while reading {url}: {e}, redownloading")
+            # remove the file if it exists
+            if path.exists():
+                subprocess.run(["rm", "-f", str(path)])
+            n_retries += 1
+            time.sleep(10)
+            continue
+        break
+
+    if n_retries == 5:
+        log(f"Failed to download {url} after 5 retries")
+
+
+def run(
+    path_out: str = "./data/",
+    links_only: bool = False,
+    n_processes: int = 4,
+):
+    """Download the PS1 PSC dataset from archive.stsci.edu/hlsps/ps1-psc/
+
+    :param path_out: output path for fetched data
+    :param links_only: only collect URLs, do not download
+    :return:
+    """
+
+    # cap the number of processes to the number of available cores if it's higher
+    # if not specified, default to 4
+    n_processes = min(mp.cpu_count(), n_processes) if n_processes > 0 else 4
+
+    links = collect_urls()
+    if links_only:
+        print(f"Links only, printing {len(links)} links and exiting:")
+        for link in links:
+            print(link["url"])
+        return
+
+    argument_lists = [(pathlib.Path(path_out), link["url"]) for link in links]
+
+    # download
+    with mp.Pool(processes=4) as pool:
+        for _ in tqdm(pool.imap(fetch_url, argument_lists), total=len(argument_lists)):
+            pass
+
+
+if __name__ == "__main__":
+    fire.Fire(run)


### PR DESCRIPTION
Some catalogs like [PS1-PSC](https://archive.stsci.edu/prepds/ps1-psc/) (provides star/galaxy score for all PS1 sources) do not provide coordinates, but the identifier of an object in another catalog that has the coordinates.

This PR adds the code needed to crossmatch (by id) new entries to the entries of an existing catalog to fetch the relevant coordinates, and add them as the coordinates of the documents of the new catalog.

Also, we refactor the main method to split it in 3 methods, one per file format