### PR TITLE
WINTER Bugix: ZTF xmatches

### DIFF
--- a/kowalski/alert_brokers/alert_broker.py
+++ b/kowalski/alert_brokers/alert_broker.py
@@ -758,12 +758,12 @@ class AlertWorker:
             #        cspjs seems to be close/good enough as an approximation
             df_light_curve["filter"] = "cspjs"
         elif self.instrument == "WNTR":
-            # 20220818: added WNTR
-            # 20220929: nir bandpasses have been added to sncosmo
-            nir_filters = {0: "ps1::y", 1: "2massj", 2: "2massh", 3: "2massks"}
+            nir_filters = {1: "ps1::y", 2: "2massj", 3: "2massh", 4: "dark"}
             df_light_curve["filter"] = df_light_curve["fid"].apply(
                 lambda x: nir_filters[x]
             )
+            # remove dark frames
+            df_light_curve = df_light_curve[df_light_curve["filter"] != "dark"]
         elif self.instrument == "TURBO":
             # the filters are just the fid values
             # TODO: add the actual filter names

--- a/kowalski/alert_brokers/alert_broker_winter.py
+++ b/kowalski/alert_brokers/alert_broker_winter.py
@@ -148,7 +148,7 @@ class WNTRAlertConsumer(AlertConsumer, ABC):
             ):
                 alert_worker.mongo.db[alert_worker.collection_alerts_aux].update_one(
                     {"_id": object_id},
-                    {"$set": {"ZTF_alerts": xmatches_ztf}},
+                    {"$set": {"cross_matches.ZTF_alerts": xmatches_ztf}},
                     upsert=True,
                 )
 


### PR DESCRIPTION
For existing WINTER objects, when recomputing ZTF crossmatches for following alerts the ZTF_alerts key wasn't added to the crossmatches but just the aux table entry