### PR TITLE
FP hists: filter out bad/weird procstatus

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -368,7 +368,6 @@ kowalski:
                           {
                             "$and":
                               [
-                                { "$eq": ["$$item.procstatus", "0"] },
                                 { "$in": ["$$item.programid", null] },
                                 {
                                   "$lt":
@@ -380,6 +379,7 @@ kowalski:
                                       365,
                                     ],
                                 },
+                                { "$eq": ["$$item.procstatus", "0"] },
                               ],
                           },
                       },

--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -368,6 +368,7 @@ kowalski:
                           {
                             "$and":
                               [
+                                { "$eq": ["$$item.procstatus", "0"] },
                                 { "$in": ["$$item.programid", null] },
                                 {
                                   "$lt":

--- a/kowalski/tests/test_alert_broker_wntr.py
+++ b/kowalski/tests/test_alert_broker_wntr.py
@@ -86,7 +86,7 @@ class TestAlertBrokerWNTR:
         assert len(df_photometry) == 1
         assert df_photometry["isdiffpos"][0] == 1.0
         assert df_photometry["diffmaglim"][0] == 17.6939640045166
-        assert df_photometry["filter"][0] == "2massh"
+        assert df_photometry["filter"][0] == "2massj"
 
     def test_make_thumbnails(self):
         alert, _, _ = self.worker.alert_mongify(self.alert)

--- a/kowalski/tests/test_alert_broker_ztf.py
+++ b/kowalski/tests/test_alert_broker_ztf.py
@@ -344,10 +344,10 @@ class TestAlertBrokerZTF:
                 post_alert(self.worker, record, fp_cutoff=1)
 
         df_photometry = self.worker.make_photometry(record, include_fp_hists=True)
-        assert len(df_photometry) == 42
+        assert len(df_photometry) == 28
         # prv_candidates have origin = None, and fp_hists have origin = 'alert_fp'
         assert "origin" in df_photometry.columns
-        assert len(df_photometry[df_photometry["origin"] == "alert_fp"]) == 21
+        assert len(df_photometry[df_photometry["origin"] == "alert_fp"]) == 7
         assert len(df_photometry[df_photometry["origin"].isnull()]) == 21
         # verify that they all have a fluxerr value
         assert all(df_photometry["fluxerr"].notnull())
@@ -1047,10 +1047,10 @@ class TestAlertBrokerZTF:
 
         assert response.status_code == 200
         photometry = response.json()["data"]
-        assert len(photometry) == 42
+        assert len(photometry) == 28
 
         assert "origin" in photometry[0]
-        assert len([p for p in photometry if p["origin"] == "alert_fp"]) == 21
+        assert len([p for p in photometry if p["origin"] == "alert_fp"]) == 7
         assert len([p for p in photometry if p["origin"] in [None, "None"]]) == 21
 
         assert (
@@ -1099,10 +1099,10 @@ class TestAlertBrokerZTF:
 
         assert response.status_code == 200
         photometry = response.json()["data"]
-        assert len(photometry) == 42
+        assert len(photometry) == 28
 
         assert "origin" in photometry[0]
-        assert len([p for p in photometry if p["origin"] == "alert_fp"]) == 21
+        assert len([p for p in photometry if p["origin"] == "alert_fp"]) == 7
         assert len([p for p in photometry if p["origin"] in [None, "None"]]) == 21
 
         assert (


### PR DESCRIPTION
Though the processing worked, some datapoints have warnings, and these signify that the data might not be what you'd expect. 

In prod we noticed a lot of deep non-detections too close to detections, and filtering out the "bad" data seems to help, though I am a bit worried about how much we will just not see anymore, but it seems like the best options right now.

We still store the data in Kowalski, but we just do not push the forced phot to Fritz if the procstatus is not "0". And yes, the 0 is a string in the ZTF alert schema...

