### PR TITLE
FP hists in broker mode: don't send unsaved

### DIFF
--- a/kowalski/alert_brokers/alert_broker_ztf.py
+++ b/kowalski/alert_brokers/alert_broker_ztf.py
@@ -148,6 +148,9 @@ class ZTFAlertConsumer(AlertConsumer, ABC):
                 < 30
             ):
                 alert_aux["fp_hists"] = fp_hists
+            else:
+                # if we don't save it, empty the fp_hists array to not send to SkyPortal what is not saved here.
+                fp_hists = []
 
             with timer(f"Aux ingesting {object_id} {candid}", alert_worker.verbose > 1):
                 retry(alert_worker.mongo.insert_one)(
@@ -184,6 +187,10 @@ class ZTFAlertConsumer(AlertConsumer, ABC):
                     == 1
                 ):
                     fp_hists = alert_worker.update_fp_hists(alert, fp_hists)
+                else:
+                    # if there is no fp_hists for this object, we don't update anything
+                    # and we empty the fp_hists array to not send to SkyPortal what is not saved here.
+                    fp_hists = []
 
         if config["misc"]["broker"]:
             # execute user-defined alert filters


### PR DESCRIPTION
We have logic here in Kowalski to only save the `fp_hists` of new objects. This is to deal with the fact that forced photometry in the alerts is a somewhat recent addition, and we don't want to start accumulating it for older objects, but only new objects where the forced photometry 30-day window might give us detections that pre-date the first alert (and that the `prv_candidates` would not have).

However, with the current logic we do not flush/empty the fp_hists variable when it's not saved to the DB, so we end up sending to SkyPortal alert-based FP that we don't save in Kowalski. Though it doesn't make the photometry we send less correct, it's confusing more than anything else.

Here, we make sure to drop the `fp_hists` before sending it to SkyPortal unless it is saved in Kowalski beforehand.