### PR TITLE
Auto-triggering: don't retrigger if there are recently (<12 h) failed requests

### DIFF
--- a/kowalski/alert_brokers/alert_broker.py
+++ b/kowalski/alert_brokers/alert_broker.py
@@ -2071,7 +2071,7 @@ class AlertWorker:
                         ]
                     )
                 ]
-                # filter out the failed requests that failed more than 12 hours. This is for to avoid
+                # filter out the failed requests that failed more than 12 hours. This is to avoid
                 # re-triggering  on objects where existing requests failed LESS than 12 hours ago.
                 #
                 # We keep these recently failed ones so that the code underneath finds an existing request and
@@ -2235,7 +2235,7 @@ class AlertWorker:
                     # if there is an existing request, but the priority is lower than the one we want to post,
                     # update the existing request with the new priority
                     request_to_update = existing_requests_filtered[0][1]
-                    # if the status is completed, deleted, or failed, do not update
+                    # if the status is completed, deleted, or failed do not update
                     if any(
                         [
                             status in str(request_to_update["status"]).lower()

--- a/kowalski/alert_brokers/alert_broker.py
+++ b/kowalski/alert_brokers/alert_broker.py
@@ -2073,7 +2073,7 @@ class AlertWorker:
                 ]
                 # filter out the failed requests that failed more than 12 hours. This is for to avoid
                 # re-triggering  on objects where existing requests failed LESS than 12 hours ago.
-                # 
+                #
                 # We keep these recently failed ones so that the code underneath finds an existing request and
                 # does not retrigger a new one. Usually, failed requests are reprocessed during the day and marked
                 # as complete, which is why we can afford to wait 12 hours before re-triggering

--- a/kowalski/alert_brokers/alert_broker.py
+++ b/kowalski/alert_brokers/alert_broker.py
@@ -2071,11 +2071,13 @@ class AlertWorker:
                         ]
                     )
                 ]
-                # filter out the failed requests that failed more than 12 hours
-                # this is for to us avoid re-triggering on requests that failed LESS than 12 hours ago
-                # we keep those recently failed ones so that the code underneath finds an existing request
-                # and does not retriggers a new one. Usually, failed requests are reprocessed during the day and marked
-                # as complete, which is why we can afford to wait 12 hours before re-triggering (basically until the next night)
+                # filter out the failed requests that failed more than 12 hours. This is for to avoid
+                # re-triggering  on objects where existing requests failed LESS than 12 hours ago.
+                # 
+                # We keep these recently failed ones so that the code underneath finds an existing request and
+                # does not retrigger a new one. Usually, failed requests are reprocessed during the day and marked
+                # as complete, which is why we can afford to wait 12 hours before re-triggering
+                # (basically until the next night)
                 now_utc = datetime.datetime.utcnow()
                 existing_requests = [
                     r


### PR DESCRIPTION
We noticed that when SEDM marked a request as failed (which happens every now and then), BTSbot would retrigger, and that could happen multiple times.

Here we make sure to keep recently (less than 12 hours) failed requests as "existing requests", to avoid triggering again. It's essentially a 12-hour timeout, which means we don't re-trigger until the next time (that is, if the requests is still failed, but most of the time these are re-processed manually in the daytime).