### PR TITLE
Skymap API PUT: trigger id bugfix

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -305,6 +305,13 @@ kowalski:
             - ["candidate.dmag2mass", -1]
           unique: false
 
+      skymaps:
+        - name: dateobs_-1_localization_name_1
+          fields:
+            - ["dateobs", -1]
+            - ["localization_name", 1]
+          unique: true
+
     filters:
       ZTF_alerts:
         # default upstream aggregation pipeline stages for filtering ZTF alerts:


### PR DESCRIPTION
- Don't look for existing skymap using a None trigger id, which ended up matching skymaps incorrectly.

- After finding and existing map, use it's `_id` to update it if needed.

- Add a unique index on dateobs + localization_name to avoid duplicates if the API code fails to find an existing map (should not happen, but it's a good failsafe anyway to have that constraint in the data model).