### PR TITLE
Auto-triggering: Overwrite the payload using the auto_followup pipeline's output + priority order

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -40,7 +40,7 @@ kowalski:
     zookeeper.test: "localhost:2181"
     path: "kafka_2.13-3.4.1"
     processes_per_topic:
-      ZTF: 2
+      ZTF: 1
 
   database:
     max_pool_size: 200

--- a/kowalski/alert_brokers/alert_broker_ztf.py
+++ b/kowalski/alert_brokers/alert_broker_ztf.py
@@ -189,7 +189,7 @@ class ZTFAlertConsumer(AlertConsumer, ABC):
             # execute user-defined alert filters
             with timer(f"Filtering of {object_id} {candid}", alert_worker.verbose > 1):
                 passed_filters = alert_worker.alert_filter__user_defined(
-                    alert_worker.filter_templates, alert, all_prv_candidates
+                    alert_worker.filter_templates, alert
                 )
             if alert_worker.verbose > 1:
                 log(

--- a/kowalski/api/api.py
+++ b/kowalski/api/api.py
@@ -85,6 +85,7 @@ AUTO_FOLLOWUP_KEYS = {
     "target_group_ids": list,
     "radius": float,
     "validity_days": int,
+    "priority_order": str,
 }
 
 
@@ -2165,6 +2166,33 @@ class FilterHandler(Handler):
                 return self.error(
                     message=f"Cannot test {attribute} pipeline: no pipeline specified"
                 )
+            elif attribute == "auto_followup" and "priority_order" in getattr(
+                filter_new, attribute
+            ):
+                if getattr(filter_new, attribute)["priority_order"] not in [
+                    "asc",
+                    "desc",
+                ]:
+                    return self.error(
+                        message=f"Invalid priority_order specified for auto_followup: {getattr(filter_new, attribute)['priority_order']}"
+                    )
+                new_priority_order = getattr(filter_new, attribute)["priority_order"]
+                new_allocation_id = getattr(filter_new, attribute)["allocation_id"]
+                # fetch all existing filters in the DB with auto_followup with the same allocation_id
+                filters_same_alloc = [
+                    f
+                    async for f in request.app["mongo"]["filters"].find(
+                        {"auto_followup.allocation_id": int(new_allocation_id)}
+                    )
+                ]
+                for f in filters_same_alloc:
+                    if (
+                        "priority_order" in f["auto_followup"]
+                        and f["auto_followup"]["priority_order"] != new_priority_order
+                    ):
+                        return self.error(
+                            message="Cannot add new filter with auto_followup: existing filters with the same allocation have priority_order set to a different value, which is unexpected"
+                        )
             pipeline = getattr(filter_new, attribute).get("pipeline")
             if not isinstance(pipeline, str):
                 pipeline = dumps(pipeline)
@@ -2439,7 +2467,34 @@ class FilterHandler(Handler):
                         return self.error(
                             message=f"Cannot update filter id {filter_id}: {modifiable_field} contains invalid keys"
                         )
-
+                    elif (
+                        modifiable_field == "auto_followup"
+                        and isinstance(value, dict)
+                        and "priority_order" in value
+                    ):
+                        # fetch all existing filters in the DB with auto_followup with the same allocation_id
+                        filters_same_alloc = [
+                            f
+                            async for f in request.app["mongo"]["filters"].find(
+                                {
+                                    "auto_followup.allocation_id": int(
+                                        value["allocation_id"]
+                                    )
+                                }
+                            )
+                        ]
+                        # if there is any filter with the same allocation_id, and a non null priority_order that is differet
+                        # throw an error. This is to avoid having multiple filters with the same allocation_id and different
+                        # priority_order, which should be fixed by a sys admin, as it should not happen
+                        for f in filters_same_alloc:
+                            if (
+                                "priority_order" in f["auto_followup"]
+                                and f["auto_followup"]["priority_order"]
+                                != value["priority_order"]
+                            ):
+                                return self.error(
+                                    message=f"Cannot update filter id {filter_id}: {modifiable_field}, filters with the same allocation have priority_order set to a different value, which is unexpected"
+                                )
                     if modifiable_field == "autosave" and isinstance(value, bool):
                         pass
                     elif isinstance(value, dict) and "pipeline" not in value:

--- a/kowalski/tests/test_alert_broker_ztf.py
+++ b/kowalski/tests/test_alert_broker_ztf.py
@@ -494,7 +494,6 @@ class TestAlertBrokerZTF:
             "validity_days": 3,
         }
         passed_filters = self.worker.alert_filter__user_defined([filter], self.alert)
-        delete_alert(self.worker, self.alert)
 
         assert passed_filters is not None
         assert len(passed_filters) == 1
@@ -514,6 +513,33 @@ class TestAlertBrokerZTF:
             "%Y-%m-%dT%H:%M:%S.%f",
         )
         assert (end_date - start_date).days == 3
+
+        # try the same but with a pipeline that overwrites the payload dynamically
+        filter["auto_followup"]["pipeline"].append(
+            {
+                "$addFields": {
+                    "payload.observation_type": "imaging",
+                    "payload.priority": 0,
+                    "comment": "Overwritten by pipeline",
+                }
+            }
+        )
+
+        passed_filters = self.worker.alert_filter__user_defined([filter], self.alert)
+        delete_alert(self.worker, self.alert)
+
+        assert passed_filters is not None
+        assert len(passed_filters) == 1
+        assert "auto_followup" in passed_filters[0]
+        assert (
+            passed_filters[0]["auto_followup"]["data"]["payload"]["observation_type"]
+            == "imaging"
+        )
+        assert passed_filters[0]["auto_followup"]["data"]["payload"]["priority"] == 0
+        assert (
+            passed_filters[0]["auto_followup"]["comment"]
+            == "Overwritten by pipeline (priority: 0)"
+        )
 
     def test_alert_filter__user_defined_followup_with_broker(self):
         """Test pushing an alert through a filter that also has auto follow-up activated, and broker mode activated"""

--- a/kowalski/tests/test_alert_broker_ztf.py
+++ b/kowalski/tests/test_alert_broker_ztf.py
@@ -707,6 +707,80 @@ class TestAlertBrokerZTF:
             followup_requests_updated[0]["id"] == followup_requests[0]["id"]
         )  # the id should be the same
 
+        # now try using a lower priority, and verify that it was not updated (still using priority 4)
+        filter2["auto_followup"]["payload"]["priority"] = 3
+        passed_filters = self.worker.alert_filter__user_defined(
+            [filter, filter2], self.alert
+        )
+
+        assert passed_filters is not None
+        assert len(passed_filters) == 2
+        assert "auto_followup" in passed_filters[0]
+
+        alert, prv_candidates, _ = self.worker.alert_mongify(self.alert)
+        self.worker.alert_sentinel_skyportal(
+            alert, prv_candidates, passed_filters=passed_filters
+        )
+
+        # now fetch the follow-up request from SP
+        # it should still be at priority 4
+        response = self.worker.api_skyportal(
+            "GET", f"/api/followup_request?sourceID={alert['objectId']}", None
+        )
+        assert response.status_code == 200
+        followup_requests_updated = response.json()["data"].get("followup_requests", [])
+        followup_requests_updated = [
+            f
+            for f in followup_requests_updated
+            if (f["allocation_id"] == allocation_id and f["status"] == "submitted")
+        ]
+        assert len(followup_requests_updated) == 1
+        assert followup_requests_updated[0]["payload"]["observation_type"] == "IFU"
+        assert followup_requests_updated[0]["payload"]["priority"] == 4
+        assert followup_requests_updated[0]["id"] == followup_requests[0]["id"]
+
+        # now we use a lower priority, but we specify for the auto_followup that lower is better for this specific allocation
+        # should be the same for a given allocation across filters, and that is set by SkyPortal when creating
+        # or editing the filter there.
+        # TODO: in the future, have kowalski fetch all of the allocations and have a mapper from allocation_id to priority_order
+        # enforced there, for all filters with the same allocation/instrument they need to trigger on.
+        filter["auto_followup"]["priority_order"] = "desc"
+        filter2["auto_followup"]["priority_order"] = "desc"
+        filter2["auto_followup"]["payload"]["priority"] = 1
+        passed_filters = self.worker.alert_filter__user_defined(
+            [filter, filter2], self.alert
+        )
+
+        assert passed_filters is not None
+        assert len(passed_filters) == 2
+        assert "auto_followup" in passed_filters[0]
+
+        alert, prv_candidates, _ = self.worker.alert_mongify(self.alert)
+        self.worker.alert_sentinel_skyportal(
+            alert, prv_candidates, passed_filters=passed_filters
+        )
+
+        # now fetch the follow-up request from SP
+        # it should now be at priority 1
+        response = self.worker.api_skyportal(
+            "GET", f"/api/followup_request?sourceID={alert['objectId']}", None
+        )
+        assert response.status_code == 200
+        followup_requests_updated = response.json()["data"].get("followup_requests", [])
+        followup_requests_updated = [
+            f
+            for f in followup_requests_updated
+            if (f["allocation_id"] == allocation_id and f["status"] == "submitted")
+        ]
+        assert len(followup_requests_updated) == 1
+        assert followup_requests_updated[0]["payload"]["observation_type"] == "IFU"
+        assert followup_requests_updated[0]["payload"]["priority"] == 1
+        assert followup_requests_updated[0]["id"] == followup_requests[0]["id"]
+
+        # set the priority_order back to normal (missing or asc, as asc should be the default)
+        filter["auto_followup"].pop("priority_order")
+        filter2["auto_followup"]["priority_order"] = "asc"
+
         # now, we'll test the target_group_ids functionality for deduplication
         # that is, if a filter has a target_group_ids, then it should only trigger a follow-up request
         # if none of the existing requests' target groups have an overlap with the target_group_ids
@@ -738,7 +812,7 @@ class TestAlertBrokerZTF:
         )
 
         # now fetch the follow-up request from SP
-        # we should still have just one follow-up request, the exact same as before
+        # we should still have just one follow-up request, same as before but back to priority 2
         response = self.worker.api_skyportal(
             "GET", f"/api/followup_request?sourceID={alert['objectId']}", None
         )
@@ -751,7 +825,7 @@ class TestAlertBrokerZTF:
         ]
         assert len(followup_requests_updated) == 1
         assert followup_requests_updated[0]["payload"]["observation_type"] == "IFU"
-        assert followup_requests_updated[0]["payload"]["priority"] == 4
+        assert followup_requests_updated[0]["payload"]["priority"] == 2
         assert followup_requests_updated[0]["id"] == followup_requests[0]["id"]
 
         # delete the follow-up request
@@ -772,6 +846,9 @@ class TestAlertBrokerZTF:
             **filter["auto_followup"],
             "comment": "SEDM triggered by BTSbot2",
         }
+        filter["auto_followup"]["payload"][
+            "priority"
+        ] = 2  # just like the filter_multiple_groups
 
         passed_filters = self.worker.alert_filter__user_defined([filter], self.alert)
         assert passed_filters is not None

--- a/kowalski/utils.py
+++ b/kowalski/utils.py
@@ -33,6 +33,7 @@ __all__ = [
     "uid",
     "ZTFAlert",
     "retry",
+    "priority_should_update",
 ]
 
 import base64
@@ -1382,3 +1383,11 @@ class ZTFAlert:
                 dmdt[:, :, i] = np.zeros((26, 26))
 
         return dmdt
+
+
+def priority_should_update(existing_priority, new_priority, priority_order="asc"):
+    # default to ascending
+    if priority_order == "desc":
+        return float(new_priority) < float(existing_priority)
+
+    return float(new_priority) > float(existing_priority)


### PR DESCRIPTION
- Simplify some of the unnecessarily complicated logic to pick the priority (a lot of options were never used).
- read the output of the auto_followup pipeline, and grab the payload (or a subset of it) and/or the comment to use for sending the trigger to SkyPortal. It will overwrite the values hardcoded in the filter saved to Kowalski's DB through Fritz.

This should allow us to have one filter that can write different payloads based on multiple parameters, to simplify BTSbot requirements as well as prepare for the next ZTF experiment where we'll auto trigger SWIFT.


ALSO, we make it possible to specify in the auto_followup section of a filter whether or not the priority system to use is ascending (higher priority is more important) or descending (lower priority is more important). We could have Kowalski fetch the full list of allocations (like we fetch the list of all filters) in the future to enforce the same thing across all filters using the same allocation, but this could be quite a lot of work just to get this system to work with SWIFT's reversed priority system. Just to be safe, we do not allow anyone to POST/PATCH a filter with the same allocation as an existing filter BUT a different priority order, to completely avoid having filters with the same follow-up payload, allocation, but different priority systems for some odd reason.