### PR TITLE
CodeQL: avoid XML external entity expansion attacks

### DIFF
--- a/kowalski/api/api.py
+++ b/kowalski/api/api.py
@@ -3305,7 +3305,8 @@ class SkymapHandler(Handler):
                     _data["voevent"] = _data["voevent"].encode("ascii")
                 except AttributeError:
                     pass
-                root = lxml.etree.fromstring(_data["voevent"])
+                parser = lxml.etree.XMLParser(resolve_entities=False)
+                root = lxml.etree.fromstring(_data["voevent"], parser)
             else:
                 raise ValueError("xml file is not valid VOEvent")
 


### PR DESCRIPTION
A suggestion from codeQL's https://github.com/skyportal/kowalski/security/code-scanning/1