### PR TITLE
Dependabot: dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: monthly
+      time: "06:00"
+    open-pull-requests-limit: 20


### PR DESCRIPTION
This PR adds a basic config to have dependabot try to update dependencies once a month