### PR TITLE
add brotli==1.1.0 to requirement/requirement.txt

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,5 +5,5 @@ jinja2>=2.11.2
 PyYAML==6.0.1
 questionary==2.0.1
 requests==2.32.3
-supervisor==4.2.
+supervisor==4.2.5
 brotli==1.1.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,4 +5,5 @@ jinja2>=2.11.2
 PyYAML==6.0.1
 questionary==2.0.1
 requests==2.32.3
-supervisor==4.2.5
+supervisor==4.2.
+brotli==1.1.0


### PR DESCRIPTION
The hope here is that if brotli is installed, python requests (used in the alert brokering stuff to talk to SkyPortal) will start using it as an accepted encoding, which should help limit the amount of data shared between SP and K. I'm curious to see if that helps even a tiiiiny bit with reducing latency, or if it does the opposite.