### PR TITLE
trim the memory less often

### DIFF
--- a/kowalski/dask_clusters/dask_cluster.py
+++ b/kowalski/dask_clusters/dask_cluster.py
@@ -40,8 +40,15 @@ if __name__ == "__main__":
     )
     log(cluster)
 
+    counter = 0
     while True:
         time.sleep(60)
         log("Heartbeat")
-        client = cluster.get_client()
-        client.run(trim_memory)
+        counter += 1
+
+        # trim memory every 10 minutes
+        if counter % 10 == 0:
+            client = cluster.get_client()
+            client.run(trim_memory)
+            log("Memory trimmed")
+            counter = 0


### PR DESCRIPTION
Trim the memory only every 10 minutes and not every minute. I noticed that when we trim the memory there is a bit of a "lag" and we lose precious time to process alerts. Doing it 10 times less should help with that, though I will monitor the impact on memory in the next couple of days.