### PR TITLE
Distance catalog default config: radius = 300" (and not 3 deg)

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -753,8 +753,8 @@ kowalski:
             yMeanPSFMagErr: 1
 
         CLU_20190625:
-          cone_search_radius: 3
-          cone_search_unit: "deg"
+          cone_search_radius: 300
+          cone_search_unit: "arcsec"
           use_distance: True
           distance_value: "z"
           distance_method: "redshift"
@@ -776,8 +776,8 @@ kowalski:
             coordinates.radec_str: 1
 
         NED_BetaV3:
-          cone_search_radius: 3
-          cone_search_unit: "deg"
+          cone_search_radius: 300
+          cone_search_unit: "radius"
           use_distance: True
           distance_value: "DistMpc"
           distance_method: "mpc"
@@ -962,8 +962,8 @@ kowalski:
             yMeanPSFMagErr: 1
 
         CLU_20190625:
-          cone_search_radius: 3
-          cone_search_unit: "deg"
+          cone_search_radius: 300
+          cone_search_unit: "arcsec"
           use_distance: True
           distance_value: "z"
           distance_method: "redshift"
@@ -1118,8 +1118,8 @@ kowalski:
             yMeanPSFMagErr: 1
 
         CLU_20190625:
-          cone_search_radius: 3
-          cone_search_unit: "deg"
+          cone_search_radius: 300
+          cone_search_unit: "arcsec"
           use_distance: True
           distance_value: "z"
           distance_method: "redshift"

--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -777,7 +777,7 @@ kowalski:
 
         NED_BetaV3:
           cone_search_radius: 300
-          cone_search_unit: "radius"
+          cone_search_unit: "arcsec"
           use_distance: True
           distance_value: "DistMpc"
           distance_method: "mpc"


### PR DESCRIPTION
The current logic for crossmatching catalogs that use distance is:
1. crossmatch with a large 3 degrees (10800 arcsec) radius
2. based on the `redshift` (z) value:
  a. if z is too small (<0.01), subsample with a fixed 300 arcsec radius.
  b. if z is large enough, subsample with a radius computed using the z.

But to me, the radius computed at large enough redshift values is always smaller than 300 arcsec (actually, always less than 150 and gets smaller as the distance grows), so we actually just never keep anything that is further than 300 arcsec away, so not sure why we use this large 3 degrees radius.

I'll re-do the math again, but if this is true, we can lower this from 3 deg (which is 10800 arcsec) to 300 arcsec, which will speed up processing alerts for new ZTF objects.