### PR TITLE
auto_followup request: ignore_allocation_ids

### DIFF
--- a/kowalski/alert_brokers/alert_broker.py
+++ b/kowalski/alert_brokers/alert_broker.py
@@ -1540,6 +1540,13 @@ class AlertWorker:
                                             )
                                         )
                                     ),
+                                    "ignore_allocation_ids": list(
+                                        set(
+                                            _filter["auto_followup"].get(
+                                                "ignore_allocation_ids", []
+                                            )
+                                        )
+                                    ),
                                     "payload": payload,
                                     # constraints
                                     "source_group_ids": [_filter["group_id"]],
@@ -2229,9 +2236,20 @@ class AlertWorker:
                     for (i, r) in enumerate(existing_requests)
                     if r["allocation_id"]
                     == passed_filter["auto_followup"]["data"]["allocation_id"]
-                    and not set(
-                        passed_filter["auto_followup"]["data"]["target_group_ids"]
-                    ).isdisjoint(set([g["id"] for g in r.get("target_groups", [])]))
+                    and (
+                        not set(
+                            passed_filter["auto_followup"]["data"]["target_group_ids"]
+                        ).isdisjoint(set([g["id"] for g in r.get("target_groups", [])]))
+                        or (
+                            len(
+                                passed_filter["auto_followup"]["data"][
+                                    "target_group_ids"
+                                ]
+                            )
+                            == 0
+                            and len(r.get("target_groups", [])) == 0
+                        )
+                    )
                     and compare_dicts(
                         passed_filter["auto_followup"]["data"]["payload"],
                         r["payload"],

--- a/kowalski/api/handlers/filter.py
+++ b/kowalski/api/handlers/filter.py
@@ -39,6 +39,7 @@ AUTO_FOLLOWUP_KEYS = {
     "allocation_id": str,
     "payload": dict,
     "target_group_ids": list,
+    "ignore_allocation_ids": list,
     "radius": float,
     "validity_days": int,
     "priority_order": str,


### PR DESCRIPTION
Adds support for the `ignore_allocation_ids` param, to let users define a list of allocations for which, if any requests exist (pending or completed) for sources within a fixed radius, SkyPortal will cancel a new trigger.

This is to help bots that run on one allocation that want to avoid triggering if there is a request for another allocation already.