### PR TITLE
WINTER watchdog: always look at the past 2 nights.

### DIFF
--- a/kowalski/alert_brokers/alert_broker_winter.py
+++ b/kowalski/alert_brokers/alert_broker_winter.py
@@ -1,5 +1,4 @@
 import argparse
-import datetime
 import multiprocessing
 import os
 import subprocess
@@ -9,6 +8,7 @@ import time
 import traceback
 from abc import ABC
 from copy import deepcopy
+from datetime import datetime, timedelta
 from typing import Mapping, Sequence
 
 import dask.distributed
@@ -536,7 +536,7 @@ def topic_listener(
     # make it unique:
     conf[
         "group.id"
-    ] = f"{conf['group.id']}_{datetime.datetime.utcnow().strftime('%Y-%m-%d_%H:%M:%S.%f')}"
+    ] = f"{conf['group.id']}_{datetime.utcnow().strftime('%Y-%m-%d_%H:%M:%S.%f')}"
 
     # Start alert stream consumer
     stream_reader = WNTRAlertConsumer(topic, dask_client, instrument="WNTR", **conf)
@@ -566,11 +566,11 @@ def topic_listener(
             sys.exit()
 
 
-def watchdog(obs_date: str = None, test: bool = False):
+def watchdog(obs_dates: str = None, test: bool = False):
     """
         Watchdog for topic listeners
 
-    :param obs_date: observing date: YYYYMMDD
+    :param obs_dates: observing date(s): YYYYMMDD, comma separated if multiple
     :param test: test mode
     :return:
     """
@@ -580,24 +580,26 @@ def watchdog(obs_date: str = None, test: bool = False):
     topics_on_watch = dict()
 
     while True:
-
         try:
-
-            if obs_date is None:
+            if obs_dates is None:
                 # for WNTR, the date that the data is sent to is the date of observation in local time
                 # not UTC, which is essentially UTC - 1 day
-                datestr = (
-                    datetime.datetime.utcnow() - datetime.timedelta(days=1)
-                ).strftime("%Y%m%d")
+                datestrs = [
+                    (datetime.utcnow() - timedelta(days=timediff)).strftime("%Y%m%d")
+                    for timediff in range(1, 2)
+                ]
             else:
-                datestr = obs_date
+                if isinstance(obs_dates, str):
+                    datestrs = [str(d) for d in obs_dates.split(",")]
+                elif isinstance(obs_dates, list):
+                    datestrs = [str(d) for d in obs_dates]
 
             # get kafka topic names with kafka-topics command
             if not test:
                 # Production Kafka stream at IPAC
 
                 # as of 20220801, the naming convention is winter_%Y%m%d
-                topics_tonight = [f"winter_{datestr}"]
+                topics_tonight = [f"winter_{datestr}" for datestr in datestrs]
             else:
                 # Local test stream
                 kafka_cmd = [
@@ -615,7 +617,9 @@ def watchdog(obs_date: str = None, test: bool = False):
 
                 # as of 20220801, the naming convention is winter_%Y%m%
                 topics_tonight = [
-                    t for t in topics if (datestr in t) and ("winter" in t)
+                    t
+                    for t in topics
+                    if (any(datestr in t for datestr in datestrs) and ("winter" in t))
                 ]
             log(f"winter: Topics tonight: {topics_tonight}")
 
@@ -669,9 +673,13 @@ def watchdog(obs_date: str = None, test: bool = False):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Kowalski's WNTR Alert Broker")
-    parser.add_argument("--obsdate", help="observing date YYYYMMDD")
+    parser.add_argument(
+        "--obsdates",
+        default=None,
+        help="observing date(s) YYYYMMDD, comma separated if multiple",
+    )
     parser.add_argument("--test", help="listen to the test stream", action="store_true")
 
     args = parser.parse_args()
 
-    watchdog(obs_date=args.obsdate, test=args.test)
+    watchdog(obs_dates=args.obsdates, test=args.test)

--- a/kowalski/tests/brokers/ingestion/test_ingester_wntr.py
+++ b/kowalski/tests/brokers/ingestion/test_ingester_wntr.py
@@ -119,7 +119,7 @@ class TestIngester:
             test=True,
         ):
             log("Starting up Ingester")
-            watchdog(obs_date=date, test=True)
+            watchdog(obs_dates=[date], test=True)
             log("Digested and ingested: all done!")
 
         log("Checking the WNTR alert collection states")


### PR DESCRIPTION
For winter since the topics are expressed in local time we already did UTC date - 1 to get the topic we want to look at.

Another issue is that at 0 UTC is when we move to new topics (when we also restart the machine every day btw), so if the WINTER alerts (that are processed and sent to IPAC manually every day, after the night of observation) are sent at or after that time, upon reboot we already are listening to the next topic and won't read the data from the previous night.

So in this PR, we just make the `obsdate` parameter a list (`obsdates`), which defaults to not just UTC -1, but UTC -1 AND UTC -2.

We could consider looking back a third day just to be safe, might want to just make that configurable at some point.