### PR TITLE
kowalski.tools.istarmap: monkey patch numpy.object

### DIFF
--- a/kowalski/tools/istarmap.py
+++ b/kowalski/tools/istarmap.py
@@ -2,6 +2,10 @@
 # See https://stackoverflow.com/questions/57354700/starmap-combined-with-tqdm
 import multiprocessing.pool as mpp
 import sys
+import numpy as np
+
+# for numpy>=1.24.0, monkey patch numpy.object
+np.object = object
 
 if sys.version_info.minor > 7:
 


### PR DESCRIPTION
Always been a little confused about this implementation, which I'm not sure is useful anymore?

That aside, to avoid things breaking with numopy>=1.24, we can just monkey patch the missing numpy type, which according to the documentation is equivalent anyways.

This is required to fix some of the unit tests