### PR TITLE
xmatch with distance: M31 & M33 exception

### DIFF
--- a/kowalski/alert_brokers/alert_broker.py
+++ b/kowalski/alert_brokers/alert_broker.py
@@ -1227,19 +1227,30 @@ class AlertWorker:
                             )
 
                     # for the exceptions below:
-                    # - the major/minor axis, axis ratio are extracted from PGC
-                    # - the position angle are extracted from SIMBAD
-                    # - from the major & minor axis, we get the semi major axis we need for the ellipse
-                    # - all the angled are in degrees
+                    # - the major/minor axis, axis ratio, and position angles come from NED
+                    #   (e.g. https://ned.ipac.caltech.edu/byname?objname=M31)
+                    # - NED numbers come from Vaucouleurs, Catalog of Bright Galaxies, 1991
+                    #   (https://www.google.com/books/edition/Third_Reference_Catalogue_of_Bright_Gala/11HuBwAAQBAJ)
+                    # - all the angles are in degrees
+                    # - we add the uncertainty to each axis and keep 6 decimal places
+                    # - we recompute the axis ratio after including these uncertainties
                     if galaxy_id == 596900:
-                        # M31 (PGC2557): angular size of 189.1x61.7 (optical), position angle of 35.0
+                        # M31 (PGC2557): 
+                        # - semi major axis = (11432.80" + 266.30") / 3600 / 2 = 1.624875 deg
+                        # - semi minor axis = (3704.23" + 171.49") / 3600 / 2 =  0.538294 deg
+                        # - axis ratio = 0.32 (if recomputed after using the uncertainties, it's 0.331283)
+                        # - positional angle = 35 deg
                         in_galaxy = in_ellipse(
-                            ra, dec, alpha1, delta01, 1.5758, 0.3263, 35.0
+                            ra, dec, alpha1, delta01, 1.624875, 0.331283, 35.0
                         )
                     elif galaxy_id == 597543:
-                        # M33 (PGC5818): angular size of 68.7x41.6 (optical), position angle of 22.0
+                        # M33 (PGC5818):
+                        # - semi major axis = (4247.70" + 98.90") / 3600 / 2 = 0.603694 deg
+                        # - semi minor axis = (2501.90" + 118.94") / 3600 / 2 =  0.364006 deg
+                        # - axis ratio = 0.59 (if recomputed after using the uncertainties, it's 0.602964)
+                        # - positional angle = 23 deg
                         in_galaxy = in_ellipse(
-                            ra, dec, alpha1, delta01, 0.5725, 0.6055, 22.0
+                            ra, dec, alpha1, delta01, 0.603694, 0.602964, 23.0
                         )
                     else:
                         in_galaxy = in_ellipse(

--- a/kowalski/alert_brokers/alert_broker.py
+++ b/kowalski/alert_brokers/alert_broker.py
@@ -1195,6 +1195,7 @@ class AlertWorker:
 
             for galaxy in galaxies + [M31, M33]:
                 try:
+                    galaxy_id = galaxy.get("_id")
                     alpha1, delta01 = galaxy["ra"], galaxy["dec"]
 
                     redshift, distmpc = None, None
@@ -1225,7 +1226,25 @@ class AlertWorker:
                                 np.arctan(catalog_cm_at_distance / (distmpc * 10**3))
                             )
 
-                    in_galaxy = in_ellipse(ra, dec, alpha1, delta01, cm_radius, 1, 0)
+                    # for the exceptions below:
+                    # - the major/minor axis, axis ratio are extracted from PGC
+                    # - the position angle are extracted from SIMBAD
+                    # - from the major & minor axis, we get the semi major axis we need for the ellipse
+                    # - all the angled are in degrees
+                    if galaxy_id == 596900:
+                        # M31 (PGC2557): angular size of 189.1x61.7 (optical), position angle of 35.0
+                        in_galaxy = in_ellipse(
+                            ra, dec, alpha1, delta01, 1.5758, 0.3263, 35.0
+                        )
+                    elif galaxy_id == 597543:
+                        # M33 (PGC5818): angular size of 68.7x41.6 (optical), position angle of 22.0
+                        in_galaxy = in_ellipse(
+                            ra, dec, alpha1, delta01, 0.5725, 0.6055, 22.0
+                        )
+                    else:
+                        in_galaxy = in_ellipse(
+                            ra, dec, alpha1, delta01, cm_radius, 1, 0
+                        )
 
                     if in_galaxy:
                         match = galaxy

--- a/kowalski/alert_brokers/alert_broker.py
+++ b/kowalski/alert_brokers/alert_broker.py
@@ -1235,7 +1235,7 @@ class AlertWorker:
                     # - we add the uncertainty to each axis and keep 6 decimal places
                     # - we recompute the axis ratio after including these uncertainties
                     if galaxy_id == 596900:
-                        # M31 (PGC2557): 
+                        # M31 (PGC2557):
                         # - semi major axis = (11432.80" + 266.30") / 3600 / 2 = 1.624875 deg
                         # - semi minor axis = (3704.23" + 171.49") / 3600 / 2 =  0.538294 deg
                         # - axis ratio = 0.32 (if recomputed after using the uncertainties, it's 0.331283)

--- a/kowalski/utils.py
+++ b/kowalski/utils.py
@@ -606,13 +606,14 @@ def great_circle_distance(ra1_deg, dec1_deg, ra2_deg, dec2_deg):
 
 
 @jit
-def in_ellipse(alpha, delta0, alpha1, delta01, d0, axis_ratio, PA0):
+def in_ellipse(alpha, delta0, alpha1, delta01, a0, axis_ratio, PA0):
     """
         Check if a given point (alpha, delta0)
         is within an ellipse specified by
-        center (alpha1, delta01), maj_ax (d0), axis ratio and positional angle
+        center (alpha1, delta01), semi_maj_ax/radius (a0), axis ratio and positional angle
         All angles are in decimal degrees
         Adapted from q3c: https://github.com/segasai/q3c/blob/master/q3cube.c
+        (PS: q3c claims the input is d0 and not a0, but the code definitely works when using radius and not a diameter as input)
     :param alpha:
     :param delta0:
     :param alpha1:
@@ -629,7 +630,7 @@ def in_ellipse(alpha, delta0, alpha1, delta01, d0, axis_ratio, PA0):
     delta1 = delta01 * DEGRA
     delta = delta0 * DEGRA
     PA = PA0 * DEGRA
-    d = d0 * DEGRA
+    a = a0 * DEGRA
     e = np.sqrt(1.0 - axis_ratio * axis_ratio)
 
     t1 = np.cos(d_alpha)
@@ -638,8 +639,8 @@ def in_ellipse(alpha, delta0, alpha1, delta01, d0, axis_ratio, PA0):
     t32 = np.sin(delta1)
     t6 = np.cos(delta)
     t26 = np.sin(delta)
-    t9 = np.cos(d)
-    t55 = np.sin(d)
+    t9 = np.cos(a)
+    t55 = np.sin(a)
 
     if (t3 * t6 * t1 + t32 * t26) < 0:
         return False


### PR DESCRIPTION
For low redshift or DistMpc galaxies, we currently use a fixed crossmatch radius (which defaults to 300 arcsec) when crossmatching alerts with galaxy catalogs that provide a distance.

This is so that low (and even negative) redshift hosts don't yield an unphysically large radius to use when verifying that an object is hosted.

However, for a few very large objects, 300 arcsec is not enough. This is the case for M31 & M33.

In this PR, we take advantage of the existing `in_ellipse()` method (but that so far we only used with circular shapes, effectively running a simple cone search) that can take an axis ratio & positional angle to use these values for these 2 large hosts, along with their semi-major axis as the radius, to make sure that the association can be made even if the object is > 300 arcsec away from the center.

TODOs:
- discuss the semi major axis / radius that should be used. Should be it be angular size of the host in the optical? Including the halo? Including some kind of offset? I'm sure someone from the TDA group at CIT has suggestions.
- write some unit tests. Already have those locally, just need to be committed and edited if we change the radius.

PS: Also noticed that the documentation of the `in_ellipse` method was not quite right. It claims that the major axis is needed (which would be the diameter of the ellipse), when clearly we always used it by passing it a radius as input and a quick test validates that it works with a radius and not a diameter. So, I also edited the docstring, variable names, and added a comment to mention that the q3c reference used to implement this method is incorrect).