### PR TITLE
Alert coordinates: Geocentric Mean ecliptic 

### DIFF
--- a/kowalski/alert_brokers/alert_broker.py
+++ b/kowalski/alert_brokers/alert_broker.py
@@ -42,6 +42,7 @@ from kowalski.utils import (
     in_ellipse,
     memoize,
     radec2lb,
+    radec2ecliptic,
     retry,
     time_stamp,
     timer,
@@ -600,6 +601,13 @@ class AlertWorker:
         doc["coordinates"]["l"] = l
         doc["coordinates"]["b"] = b
 
+        # Ecliptic coordinates (lambda, beta)
+        lambda_, beta = radec2ecliptic(doc["candidate"]["ra"], doc["candidate"]["dec"])
+        doc["coordinates"]["geocentricmeanecliptic"] = {
+            "lambda": lambda_,
+            "beta": beta,
+        }
+
         prv_candidates = deepcopy(doc["prv_candidates"])
         doc.pop("prv_candidates", None)
         if prv_candidates is None:
@@ -637,7 +645,7 @@ class AlertWorker:
                 image_data = hdu[0].data
 
         # Survey-specific transformations to get North up and West on the right
-        if self.instrument in ["ZTF", "WNTR"]:
+        if self.instrument in ["ZTF"]:
             image_data = np.flipud(image_data)
         elif self.instrument == "PGIR":
             image_data = np.rot90(np.fliplr(image_data), 3)

--- a/kowalski/api/handlers/alerts.py
+++ b/kowalski/api/handlers/alerts.py
@@ -229,7 +229,7 @@ class AlertCutoutHandler(BaseHandler):
                     image_data = hdu[0].data
 
             # Survey-specific transformations to get North up and West on the right
-            if survey in ["ztf", "wntr"]:
+            if survey in ["ztf"]:
                 image_data = np.flipud(image_data)
             elif survey in ["pgir"]:
                 image_data = np.rot90(np.fliplr(image_data), 3)

--- a/kowalski/utils.py
+++ b/kowalski/utils.py
@@ -25,6 +25,7 @@ __all__ = [
     "radec_str2rad",
     "radec_str2geojson",
     "radec2lb",
+    "radec2ecliptic",
     "sdss_url",
     "str_to_numeric",
     "time_stamp",
@@ -708,6 +709,16 @@ RGE = np.array(
     ]
 )
 
+# equatorial to ecliptic, where the obligness of the ecliptic is 23.439291 degrees (earth orbital plane)
+EARTH_OBL = 23.439291
+EQ2ECL = np.array(
+    [
+        [1, 0, 0],
+        [0, np.cos(EARTH_OBL * np.pi / 180.0), np.sin(EARTH_OBL * np.pi / 180.0)],
+        [0, -np.sin(EARTH_OBL * np.pi / 180.0), np.cos(EARTH_OBL * np.pi / 180.0)],
+    ]
+)
+
 
 def radec2lb(ra, dec):
     """
@@ -732,6 +743,31 @@ def radec2lb(ra, dec):
     galactic_l = np.arctan2(y, x)
     galactic_b = np.arctan2(z, (x * x + y * y) ** 0.5)
     return np.rad2deg(galactic_l), np.rad2deg(galactic_b)
+
+
+def radec2ecliptic(ra, dec):
+    """
+        Convert $R.A.$ and $Decl.$ into Ecliptic coordinates
+    ra [deg]
+    dec [deg]
+
+    return ecliptic_lon [deg], ecliptic_lat [deg]
+    """
+    ra_rad, dec_rad = np.deg2rad(ra), np.deg2rad(dec)
+    u = np.array(
+        [
+            np.cos(ra_rad) * np.cos(dec_rad),
+            np.sin(ra_rad) * np.cos(dec_rad),
+            np.sin(dec_rad),
+        ]
+    )
+
+    ue = np.dot(EQ2ECL, u)
+
+    x, y, z = ue
+    ecliptic_lon = np.arctan2(y, x)
+    ecliptic_lat = np.arctan2(z, (x * x + y * y) ** 0.5)
+    return np.rad2deg(ecliptic_lon) % 360, np.rad2deg(ecliptic_lat)
 
 
 def datetime_to_jd(_t: datetime.datetime) -> float:


### PR DESCRIPTION
This PR:
- adds a radec2ecliptic method, that computes the geocentric mean ecliptic coordinates of a given ra/dec input.
- uses that new method to add a `geocentricmeanecliptic` field to the alert's `coordinates`, with `lambda` (longitude) and `alpha` (latitude). This can then easily be used in any alert filters that might want to look for or exclude things on the ecliptic plane.
- doesn't flip the thumbnails of WINTER alerts.

The idea here is to build filters like: "if a transient has no PS1 counterpart & is too close to the ecliptic plane, discard it"