### PR TITLE
autotrigger: not_if_tns_reported

### DIFF
--- a/kowalski/alert_brokers/alert_broker.py
+++ b/kowalski/alert_brokers/alert_broker.py
@@ -1624,15 +1624,13 @@ class AlertWorker:
                             }
 
                             if _filter["auto_followup"].get(
-                                "no_tns_source_older_than", None
+                                "not_if_tns_reported", None
                             ):
                                 try:
                                     passed_filter["auto_followup"]["data"][
-                                        "no_tns_source_older_than"
+                                        "not_if_tns_reported"
                                     ] = int(
-                                        _filter["auto_followup"][
-                                            "no_tns_source_older_than"
-                                        ]
+                                        _filter["auto_followup"]["not_if_tns_reported"]
                                     )
                                 except Exception:
                                     log(

--- a/kowalski/alert_brokers/alert_broker.py
+++ b/kowalski/alert_brokers/alert_broker.py
@@ -1623,6 +1623,22 @@ class AlertWorker:
                                 ),  # by default we assume that update is implemented for the instrument of this allocation
                             }
 
+                            if _filter["auto_followup"].get(
+                                "no_tns_source_older_than", None
+                            ):
+                                try:
+                                    passed_filter["auto_followup"]["data"][
+                                        "no_tns_source_older_than"
+                                    ] = int(
+                                        _filter["auto_followup"][
+                                            "no_tns_source_older_than"
+                                        ]
+                                    )
+                                except Exception:
+                                    log(
+                                        f'Filter {_filter["fid"]} has an invalid auto-followup no_tns_older_than, skipping'
+                                    )
+
                             if not isinstance(_filter.get("autosave", False), bool):
                                 passed_filter["auto_followup"]["data"][
                                     "ignore_source_group_ids"

--- a/kowalski/api/handlers/filter.py
+++ b/kowalski/api/handlers/filter.py
@@ -40,6 +40,7 @@ AUTO_FOLLOWUP_KEYS = {
     "payload": dict,
     "target_group_ids": list,
     "ignore_allocation_ids": list,
+    "no_tns_source_older_than": int,  # hours
     "radius": float,
     "validity_days": int,
     "priority_order": str,

--- a/kowalski/api/handlers/filter.py
+++ b/kowalski/api/handlers/filter.py
@@ -40,7 +40,7 @@ AUTO_FOLLOWUP_KEYS = {
     "payload": dict,
     "target_group_ids": list,
     "ignore_allocation_ids": list,
-    "no_tns_source_older_than": int,  # hours
+    "not_if_tns_reported": int,  # hours
     "radius": float,
     "validity_days": int,
     "priority_order": str,


### PR DESCRIPTION
Adds an optional `not_if_tns_reported` (in hours) parameter, that Kowalski can then send to Fritz to let it cancel autotriggers on objects that already have been reported on TNS a while ago.