### PR TITLE
Confluent kafka downgrade + worker reregistration deduplication

### DIFF
--- a/kowalski/alert_brokers/alert_broker_pgir.py
+++ b/kowalski/alert_brokers/alert_broker_pgir.py
@@ -507,8 +507,10 @@ def topic_listener(
     )
 
     # init each worker with AlertWorker instance
+    # idempotent=True ensures that the plugin is not registered multiple times
+    # if there is a topic_listener restart (e.g., due to a Kafka error)
     worker_initializer = WorkerInitializer()
-    dask_client.register_plugin(worker_initializer, name="worker-init")
+    dask_client.register_plugin(worker_initializer, name="worker-init", idempotent=True)
 
     # Configure consumer connection to Kafka broker
     conf = {

--- a/kowalski/alert_brokers/alert_broker_turbo.py
+++ b/kowalski/alert_brokers/alert_broker_turbo.py
@@ -483,8 +483,10 @@ def topic_listener(
     )
 
     # init each worker with AlertWorker instance
+    # idempotent=True ensures that the plugin is not registered multiple times
+    # if there is a topic_listener restart (e.g., due to a Kafka error)
     worker_initializer = WorkerInitializer()
-    dask_client.register_plugin(worker_initializer, name="worker-init")
+    dask_client.register_plugin(worker_initializer, name="worker-init", idempotent=True)
 
     # Configure consumer connection to Kafka broker
     conf = {

--- a/kowalski/alert_brokers/alert_broker_winter.py
+++ b/kowalski/alert_brokers/alert_broker_winter.py
@@ -517,9 +517,13 @@ def topic_listener(
         address=f"{config['dask_wntr']['host']}:{config['dask_wntr']['scheduler_port']}"
     )
     # init each worker with AlertWorker instance
+    # idempotent=True ensures that the plugin is not registered multiple times
+    # if there is a topic_listener restart (e.g., due to a Kafka error)
     worker_initializer = WorkerInitializer()
     try:
-        dask_client.register_plugin(worker_initializer, name="worker-init")
+        dask_client.register_plugin(
+            worker_initializer, name="worker-init", idempotent=True
+        )
     except Exception as e:
         log(f"Failed to register worker plugin: {e}")
         log(f"Traceback: {traceback.format_exc()}")

--- a/requirements/requirements_ingester.txt
+++ b/requirements/requirements_ingester.txt
@@ -2,11 +2,11 @@ astropy==6.1.4
 bcrypt==4.2.0
 beautifulsoup4==4.12.3
 bokeh==3.4.2
-confluent-kafka==2.6.0
+confluent-kafka==2.5.3
 cryptography==43.0.3
-dask==2024.8.0
+dask==2024.10.0
 deepdiff==8.0.1
-distributed==2024.8.0
+distributed==2024.10.0
 fastavro==1.6.0 #breaking changes in newer versions
 fire==0.6.0
 gsutil==5.30


### PR DESCRIPTION
This PR:

- downgrades the "dependabot updated" confluent-kafka (from 2.6.0 back to 2.5.3), as the new version creates authentication issues.
- Registering/restarting new topic listener now also avoids registering workers if they are already registered on the cluster/scheduler, which created memory leaks when we kept timing out from the kafka topics and registering the workers again and again.
- I also remove some unnecessary logs from the ZTF workers, that have been polluting the logs for some time now and make it hard to find relevant lines when this kind of error occurs.