### PR TITLE
pip + virtualenv -> uv

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
           uv venv env --python=python3.10
           source env/bin/activate
           python --version
-          pip install setuptools
+          uv pip install packaging setuptools
 
       - name: Set up configs
         env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,10 +17,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install "wheel>=0.36.0"
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,10 +15,6 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
 
@@ -27,6 +23,12 @@ jobs:
           path: |
             ~/.cache/uv
           key: ${{ runner.os }}-${{ hashFiles('**/requirements*.txt') }}
+
+      - name: Set up virtualenv
+        run: |
+          uv venv env --python=python3.10
+          source env/bin/activate
+          python --version
 
       - name: Set up configs
         env:
@@ -44,13 +46,17 @@ jobs:
           EOF
 
       - name: Build and spin up
-        run: make docker_build && make docker_up
+        run: |
+          source env/bin/activate
+          make docker_build && make docker_up
 
       - name: Cooldown to let the app start
         run: sleep 10
 
       - name: Run tests
-        run: make docker_test
+        run: |
+          source env/bin/activate
+          make docker_test
 
       - name: Collect Docker Logs
         uses: jwalton/gh-docker-logs@v2.2.2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,16 +14,20 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
+
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
       - uses: actions/cache@v4
         with:
           path: |
-            ~/.cache/pip
+            ~/.cache/uv
           key: ${{ runner.os }}-${{ hashFiles('**/requirements*.txt') }}
+
       - name: Set up configs
         env:
           TNS_BOT_ID: ${{ secrets.TNS_BOT_ID }}
@@ -38,17 +42,22 @@ jobs:
               bot_name: $TNS_BOT_NAME
               api_key: $TNS_API_KEY
           EOF
+
       - name: Build and spin up
         run: make docker_build && make docker_up
+
       - name: Cooldown to let the app start
         run: sleep 10
+
       - name: Run tests
         run: make docker_test
+
       - name: Collect Docker Logs
         uses: jwalton/gh-docker-logs@v2.2.2
         with:
           images: 'skyportal/kowalski-ingester,skyportal/kowalski-api,kowalski-mongo'
           dest: './logs'
+
       - name: Upload logs
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,6 +29,7 @@ jobs:
           uv venv env --python=python3.10
           source env/bin/activate
           python --version
+          pip install setuptools
 
       - name: Set up configs
         env:

--- a/Makefile
+++ b/Makefile
@@ -25,17 +25,21 @@ SUPERVISORCTL_INGESTER=$(PYTHON) -m supervisor.supervisorctl -c $(SUPERVISORD_IN
 system_dependencies:
 	$(PYTHON) kowalski/tools/check_app_environment.py
 
+# check if pkg_resources is installed and if not then install it
+check_python_packaging:
+	uv pip freeze | grep -q 'packaging' || uv pip install packaging setuptools
+
 # DEPENDENCIES
-python_dependencies:
+python_dependencies: check_python_packaging
 	$(PYTHON) kowalski/tools/install_python_requirements.py requirements/requirements.txt
 
-python_dependencies_api:
+python_dependencies_api: check_python_packaging
 	$(PYTHON) kowalski/tools/install_python_requirements.py requirements/requirements_api.txt
 
-python_dependencies_ingester:
+python_dependencies_ingester: check_python_packaging
 	$(PYTHON) kowalski/tools/install_python_requirements.py requirements/requirements_ingester.txt
 
-python_dependencies_test:
+python_dependencies_test: check_python_packaging
 	$(PYTHON) kowalski/tools/install_python_requirements.py requirements/requirements_test.txt
 
 # SUPERVISORD

--- a/Makefile
+++ b/Makefile
@@ -27,16 +27,16 @@ system_dependencies:
 
 # DEPENDENCIES
 python_dependencies:
-	$(PYTHON) kowalski/tools/pip_install_requirements.py requirements/requirements.txt
+	$(PYTHON) kowalski/tools/install_python_requirements.py requirements/requirements.txt
 
 python_dependencies_api:
-	$(PYTHON) kowalski/tools/pip_install_requirements.py requirements/requirements_api.txt
+	$(PYTHON) kowalski/tools/install_python_requirements.py requirements/requirements_api.txt
 
 python_dependencies_ingester:
-	$(PYTHON) kowalski/tools/pip_install_requirements.py requirements/requirements_ingester.txt
+	$(PYTHON) kowalski/tools/install_python_requirements.py requirements/requirements_ingester.txt
 
 python_dependencies_test:
-	$(PYTHON) kowalski/tools/pip_install_requirements.py requirements/requirements_test.txt
+	$(PYTHON) kowalski/tools/install_python_requirements.py requirements/requirements_test.txt
 
 # SUPERVISORD
 generate_supervisord_conf:

--- a/README.md
+++ b/README.md
@@ -61,27 +61,27 @@ First, you'll need to install few system dependencies:
 sudo apt install -y default-jdk wget
 ```
 
-Make sure you have a version of python that is 3.8 or above before following the next steps.
-
-Now, in the **same** terminal, run:
+Then, though you can use virtualenv or conda, we recommend using `uv` to manage your python environment and dependencies. To install `uv`, run:
 
 ```bash
-sudo pip install virtualenv
-virtualenv env
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+Now, to create a virtual environment with python 3.10 (or above, up to 3.13 excluded), run:
+
+```bash
+uv venv env --python=python3.10
 source env/bin/activate
 ```
 
-to create your virtual environment. If you are told that pip is not found, try using pip3 instead. For the following steps however (in the virtualenv), pip should work.
-
-
-The python dependencies will be install automatically when you start the app. The same will happen for Kafka and the ML models.
+No need to install the dependencies now, as they will be installed automatically when you start the app. The same will happen for Kafka, and the ML models.
 
 ### Environment setup **on MacOS arm64 (M1 or M2)**
 
 First, you need to install several system dependencies using [homebrew](https://brew.sh):
 
 ```bash
-brew install java librdkafka wget
+brew install java librdkafka wget uv
 ```
 
 After installing java, run the following to make sure it is accessible by kafka later on:
@@ -89,42 +89,25 @@ After installing java, run the following to make sure it is accessible by kafka 
 sudo ln -sfn /opt/homebrew/opt/openjdk/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk.jdk
 echo 'export PATH="/opt/homebrew/opt/openjdk/bin:$PATH"' >> ~/.zshrc
 ```
-Seperately, we install hdf5:
+
+Separately, we install hdf5:
 ```bash
 brew install hdf5
 ```
-At the end of hdf5's installation, the path where it has been installed will be displayed in your terminal. Copy that path and make sure that you save it somewhere. You will need it when installing or updating python dependencies. We suggest you save it to your `.bashrc` or `.zshrc` file, by adding the following line:
+At the end of hdf5's installation, the path where it has been installed will be displayed in your terminal. Copy that path (including the version that is at the end of it!), and save it to your save it to your `.zshrc` file (or `.bashrc` if you are using bash) by adding the following line:
 ```bash
-export HDF5_DIR=<path_to_hdf5>
+export HDF5_DIR=<path_to_hdf5>/<version>
 ```
+This is required to install `pytables` later on.
 
-*Don't forget to source your `.zshrc` file after adding the above line, or else the path will not be accessible. You can also simply restart your terminal.*
+*Don't forget to source your `.zshrc` file after adding the above line, or else the path will not be accessible. You can also simply restart your terminal and enter the virtual environment again.*
 
-Make sure you have a version of python that is 3.8 or above before following the next steps. You can consider installing a newer version with `homebrew` if needed.
-
-To install a new version with homebrew, run:
-```bash
-brew install python@3.10
-```
-and then add the following line to your `.bashrc` or `.zshrc` file:
-```bash
-alias python='python3.10'
-alias pip='pip3.10'
-```
-
-These lines will allow you to use that binary when calling python in your terminal. You can also use `python3.10` instead of `python` in the following steps.
-
-*If you added it to your `.zshrc` file, don't forget to source it.*
-
-Now, in the **same** terminal, run:
+Now, to create a virtual environment with python 3.10 (or above, up to 3.13 excluded), run:
 
 ```bash
-sudo pip install virtualenv
-virtualenv env
+uv venv env --python=python3.10
 source env/bin/activate
 ```
-
-to create your virtual environment. If you are told that pip is not found, try using pip3 instead. For the following steps however (in the virtualenv), pip should work.
 
 The python dependencies will be install automatically when you start the app. The same will happen for Kafka and the ML models.
 

--- a/api.Dockerfile
+++ b/api.Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.10
 
+WORKDIR /kowalski
+
 RUN apt-get update && \
     apt-get install -y curl && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y && \
@@ -7,19 +9,18 @@ RUN apt-get update && \
     apt-get install -y libssl-dev && \
     apt-get install -y libffi-dev && \
     apt-get install -y python3-dev && \
-    apt-get install -y cargo && \
-    curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    uv venv env --python=python3.10
+    apt-get install -y cargo
 
+ENV VIRTUAL_ENV=/usr/local
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# ls the content of /root/.cargo/bin
-RUN ls /root/.cargo/bin
-
-WORKDIR /kowalski
+SHELL ["/bin/bash", "-c"]
 
 # place to keep our app and the data:
 RUN mkdir -p data logs /_tmp
+
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
+    uv venv env --python=python3.10
 
 COPY requirements/ requirements/
 
@@ -57,4 +58,4 @@ RUN source env/bin/activate && \
     uv pip install -r requirements/requirements_test.txt --no-cache-dir
 
 # run container
-CMD make run_api
+CMD ["/bin/bash", "-c", "source env/bin/activate && make run_api"]

--- a/api.Dockerfile
+++ b/api.Dockerfile
@@ -13,10 +13,10 @@ RUN apt-get update && \
 
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# place to keep our app and the data:
-RUN mkdir -p /kowalski /kowalski/data /kowalski/logs /_tmp
-
 WORKDIR /kowalski
+
+# place to keep our app and the data:
+RUN mkdir -p data logs /_tmp
 
 COPY requirements/ requirements/
 

--- a/api.Dockerfile
+++ b/api.Dockerfile
@@ -9,7 +9,7 @@ SHELL ["/bin/bash", "-c"]
 
 ENV VIRTUAL_ENV=/usr/local
 
-RUN apt-get update && apt-get install -y curl wget && \
+RUN apt-get update && apt-get install -y curl wget clang && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y && \
     apt-get install -y build-essential libssl-dev libffi-dev python3-dev cargo
 

--- a/api.Dockerfile
+++ b/api.Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update && \
     apt-get install -y libssl-dev && \
     apt-get install -y libffi-dev && \
     apt-get install -y python3-dev && \
-    apt-get install -y cargo
+    apt-get install -y cargo && \
+    curl -LsSf https://astral.sh/uv/install.sh | sh
 
 ENV PATH="/root/.cargo/bin:${PATH}"
 
@@ -35,7 +36,7 @@ COPY kowalski/api kowalski/api
 COPY ["kowalski/tools/__init__.py", \
         "kowalski/tools/check_app_environment.py", \
         "kowalski/tools/generate_supervisord_conf.py", \
-        "kowalski/tools/pip_install_requirements.py", \
+        "kowalski/tools/install_python_requirements.py", \
         "kowalski/tools/watch_logs.py", \
         "kowalski/tools/gcn_utils.py", \
         "kowalski/tools/"]
@@ -46,14 +47,10 @@ COPY conf/supervisord_api.conf.template conf/
 
 COPY Makefile .
 
-
-# upgrade pip
-RUN pip install --upgrade pip
-
 # install python libs and generate supervisord config file
-RUN pip install -r requirements/requirements.txt --no-cache-dir && \
-    pip install -r requirements/requirements_api.txt --no-cache-dir && \
-    pip install -r requirements/requirements_test.txt --no-cache-dir
+RUN uv pip install -r requirements/requirements.txt --no-cache-dir && \
+    uv pip install -r requirements/requirements_api.txt --no-cache-dir && \
+    uv pip install -r requirements/requirements_test.txt --no-cache-dir
 
 # run container
 CMD make run_api

--- a/api.Dockerfile
+++ b/api.Dockerfile
@@ -11,10 +11,10 @@ RUN apt-get update && \
     apt-get install -y python3-dev && \
     apt-get install -y cargo
 
+SHELL ["/bin/bash", "-c"]
+
 ENV VIRTUAL_ENV=/usr/local
 ENV PATH="/root/.cargo/bin:${PATH}"
-
-SHELL ["/bin/bash", "-c"]
 
 # place to keep our app and the data:
 RUN mkdir -p data logs /_tmp

--- a/api.Dockerfile
+++ b/api.Dockerfile
@@ -1,5 +1,4 @@
 FROM python:3.10
-#FROM python:3.7-slim
 
 RUN apt-get update && \
     apt-get install -y curl && \
@@ -9,7 +8,8 @@ RUN apt-get update && \
     apt-get install -y libffi-dev && \
     apt-get install -y python3-dev && \
     apt-get install -y cargo && \
-    curl -LsSf https://astral.sh/uv/install.sh | sh
+    curl -LsSf https://astral.sh/uv/install.sh | sh && \
+    uv venv env --python=python3.10
 
 ENV PATH="/root/.cargo/bin:${PATH}"
 
@@ -48,7 +48,8 @@ COPY conf/supervisord_api.conf.template conf/
 COPY Makefile .
 
 # install python libs and generate supervisord config file
-RUN uv pip install -r requirements/requirements.txt --no-cache-dir && \
+RUN source env/bin/activate && \
+    uv pip install -r requirements/requirements.txt --no-cache-dir && \
     uv pip install -r requirements/requirements_api.txt --no-cache-dir && \
     uv pip install -r requirements/requirements_test.txt --no-cache-dir
 

--- a/api.Dockerfile
+++ b/api.Dockerfile
@@ -13,6 +13,9 @@ RUN apt-get update && \
 
 ENV PATH="/root/.cargo/bin:${PATH}"
 
+# ls the content of /root/.cargo/bin
+RUN ls /root/.cargo/bin
+
 WORKDIR /kowalski
 
 # place to keep our app and the data:

--- a/ingester.Dockerfile
+++ b/ingester.Dockerfile
@@ -125,4 +125,4 @@ RUN source env/bin/activate && \
     uv pip install -r requirements/requirements_test.txt --no-cache-dir
 
 # run container
-CMD  source env/bin/activate && make run_ingester
+CMD ["/bin/bash", "-c", "source env/bin/activate && make run_ingester"]

--- a/ingester.Dockerfile
+++ b/ingester.Dockerfile
@@ -129,5 +129,8 @@ RUN source env/bin/activate && \
     uv pip install -r requirements/requirements_test.txt && \
     uv pip install -r requirements/requirements_ingester.txt
 
+# remove cached files
+RUN rm -rf $HOME/.cache/uv
+
 # run container
 CMD ["/bin/bash", "-c", "source env/bin/activate && make run_ingester"]

--- a/ingester.Dockerfile
+++ b/ingester.Dockerfile
@@ -25,6 +25,9 @@ RUN apt-get update && apt-get install -y default-jdk && \
     curl -LsSf https://astral.sh/uv/install.sh | sh && \
     uv venv env --python=python3.10
 
+# ls the content of /root/.cargo/bin
+RUN ls /root/.cargo/bin
+
 # Kafka test-server properties:
 COPY server.properties kafka_$scala_version-$kafka_version/config/
 

--- a/ingester.Dockerfile
+++ b/ingester.Dockerfile
@@ -18,11 +18,12 @@ RUN mkdir -p /kowalski /kowalski/data /kowalski/logs /_tmp /kowalski/models/pgir
 
 WORKDIR /kowalski
 
-# Install jdk, mkdirs, uv, fetch and install Kafka
+# Install jdk, mkdirs, uv, fetch and install Kafka, create virtualenv
 RUN apt-get update && apt-get install -y default-jdk && \
-    wget https://archive.apache.org/dist/kafka/$kafka_version/kafka_$scala_version-$kafka_version.tgz -O kafka_$scala_version-$kafka_version.tgz && \
+    wget https://archive.apache.org/dist/kafka/$kafka_version/kafka_$scala_version-$kafka_version.tgz --no-verbose -O kafka_$scala_version-$kafka_version.tgz && \
     tar -xzf kafka_$scala_version-$kafka_version.tgz && \
-    curl -LsSf https://astral.sh/uv/install.sh | sh
+    curl -LsSf https://astral.sh/uv/install.sh | sh && \
+    uv venv env --python=python3.10
 
 # Kafka test-server properties:
 COPY server.properties kafka_$scala_version-$kafka_version/config/
@@ -112,9 +113,10 @@ COPY Makefile .
 ENV USING_DOCKER=true
 
 # install python libs and generate supervisord config file
-RUN uv pip install -r requirements/requirements.txt --no-cache-dir && \
+RUN source env/bin/activate && \
+    uv pip install -r requirements/requirements.txt --no-cache-dir && \
     uv pip install -r requirements/requirements_ingester.txt --no-cache-dir && \
     uv pip install -r requirements/requirements_test.txt --no-cache-dir
 
 # run container
-CMD make run_ingester
+CMD  source env/bin/activate && make run_ingester

--- a/ingester.Dockerfile
+++ b/ingester.Dockerfile
@@ -13,20 +13,23 @@ ARG acai_b_version=d1_dnn_20201130
 #RUN apt-get update && apt-get -y install apt-file && apt-file update && apt-get -y install vim && \
 #    apt-get -y install git && apt-get install -y default-jdk
 
-# place to keep our app and the data:
-RUN mkdir -p /kowalski /kowalski/data /kowalski/logs /_tmp /kowalski/models/pgir /kowalski/models/ztf /kowalski/models/wntr /kowalski/models/turbo
-
 WORKDIR /kowalski
 
 # Install jdk, mkdirs, uv, fetch and install Kafka, create virtualenv
 RUN apt-get update && apt-get install -y default-jdk && \
     wget https://archive.apache.org/dist/kafka/$kafka_version/kafka_$scala_version-$kafka_version.tgz --no-verbose -O kafka_$scala_version-$kafka_version.tgz && \
-    tar -xzf kafka_$scala_version-$kafka_version.tgz && \
-    curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    uv venv env --python=python3.10
+    tar -xzf kafka_$scala_version-$kafka_version.tgz
 
-# ls the content of /root/.cargo/bin
-RUN ls /root/.cargo/bin
+ENV VIRTUAL_ENV=/usr/local
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+SHELL ["/bin/bash", "-c"]
+
+# place to keep our app and the data:
+RUN mkdir -p data logs /_tmp models/pgir models/ztf models/wntr models/turbo
+
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
+    uv venv env --python=python3.10
 
 # Kafka test-server properties:
 COPY server.properties kafka_$scala_version-$kafka_version/config/

--- a/ingester.Dockerfile
+++ b/ingester.Dockerfile
@@ -23,7 +23,7 @@ ENV VIRTUAL_ENV=/usr/local
 #    apt-get -y install git && apt-get install -y default-jdk
 
 # Install jdk, mkdirs, uv, fetch and install Kafka
-RUN apt-get update && apt-get install -y curl wget default-jdk build-essential gcc clang
+RUN apt-get update && apt-get install -y curl wget default-jdk build-essential gcc
 
 RUN wget https://archive.apache.org/dist/kafka/$kafka_version/kafka_$scala_version-$kafka_version.tgz --no-verbose -O kafka_$scala_version-$kafka_version.tgz && \
     tar -xzf kafka_$scala_version-$kafka_version.tgz

--- a/ingester.Dockerfile
+++ b/ingester.Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.10
 
+WORKDIR /kowalski
+
 ARG scala_version=2.13
 ARG kafka_version=3.4.1
 ARG braai_version=d6_m9
@@ -13,17 +15,15 @@ ARG acai_b_version=d1_dnn_20201130
 #RUN apt-get update && apt-get -y install apt-file && apt-file update && apt-get -y install vim && \
 #    apt-get -y install git && apt-get install -y default-jdk
 
-WORKDIR /kowalski
-
-# Install jdk, mkdirs, uv, fetch and install Kafka, create virtualenv
+# Install jdk, mkdirs, uv, fetch and install Kafka
 RUN apt-get update && apt-get install -y default-jdk && \
     wget https://archive.apache.org/dist/kafka/$kafka_version/kafka_$scala_version-$kafka_version.tgz --no-verbose -O kafka_$scala_version-$kafka_version.tgz && \
     tar -xzf kafka_$scala_version-$kafka_version.tgz
 
+SHELL ["/bin/bash", "-c"]
+
 ENV VIRTUAL_ENV=/usr/local
 ENV PATH="/root/.cargo/bin:${PATH}"
-
-SHELL ["/bin/bash", "-c"]
 
 # place to keep our app and the data:
 RUN mkdir -p data logs /_tmp models/pgir models/ztf models/wntr models/turbo

--- a/ingester.Dockerfile
+++ b/ingester.Dockerfile
@@ -18,10 +18,11 @@ RUN mkdir -p /kowalski /kowalski/data /kowalski/logs /_tmp /kowalski/models/pgir
 
 WORKDIR /kowalski
 
-# Install jdk, mkdirs, fetch and install Kafka
+# Install jdk, mkdirs, uv, fetch and install Kafka
 RUN apt-get update && apt-get install -y default-jdk && \
     wget https://archive.apache.org/dist/kafka/$kafka_version/kafka_$scala_version-$kafka_version.tgz -O kafka_$scala_version-$kafka_version.tgz && \
-    tar -xzf kafka_$scala_version-$kafka_version.tgz
+    tar -xzf kafka_$scala_version-$kafka_version.tgz && \
+    curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # Kafka test-server properties:
 COPY server.properties kafka_$scala_version-$kafka_version/config/
@@ -60,7 +61,7 @@ COPY ["kowalski/tools/__init__.py", \
     "kowalski/tools/kafka_stream.py", \
     "kowalski/tools/ops_watcher_ztf.py", \
     "kowalski/tools/performance_reporter.py", \
-    "kowalski/tools/pip_install_requirements.py", \
+    "kowalski/tools/install_python_requirements.py", \
     "kowalski/tools/tns_watcher.py", \
     "kowalski/tools/watch_logs.py", \
     "kowalski/tools/"]
@@ -110,13 +111,10 @@ COPY Makefile .
 
 ENV USING_DOCKER=true
 
-# update pip
-RUN pip install --upgrade pip
-
 # install python libs and generate supervisord config file
-RUN pip install -r requirements/requirements.txt --no-cache-dir && \
-    pip install -r requirements/requirements_ingester.txt --no-cache-dir && \
-    pip install -r requirements/requirements_test.txt --no-cache-dir
+RUN uv pip install -r requirements/requirements.txt --no-cache-dir && \
+    uv pip install -r requirements/requirements_ingester.txt --no-cache-dir && \
+    uv pip install -r requirements/requirements_test.txt --no-cache-dir
 
 # run container
 CMD make run_ingester

--- a/ingester.Dockerfile
+++ b/ingester.Dockerfile
@@ -23,7 +23,7 @@ ENV VIRTUAL_ENV=/usr/local
 #    apt-get -y install git && apt-get install -y default-jdk
 
 # Install jdk, mkdirs, uv, fetch and install Kafka
-RUN apt-get update && apt-get install -y curl wget default-jdk build-essential gcc
+RUN apt-get update && apt-get install -y curl wget default-jdk build-essential gcc clang
 
 RUN wget https://archive.apache.org/dist/kafka/$kafka_version/kafka_$scala_version-$kafka_version.tgz --no-verbose -O kafka_$scala_version-$kafka_version.tgz && \
     tar -xzf kafka_$scala_version-$kafka_version.tgz

--- a/kowalski/tools/install_python_requirements.py
+++ b/kowalski/tools/install_python_requirements.py
@@ -6,7 +6,7 @@ from pkg_resources import DistributionNotFound, Requirement, VersionConflict
 
 if len(sys.argv) < 2:
     print(
-        "Usage: pip_install_requirements.py requirements.txt [requirements_other.txt]"
+        "Usage: install_python_requirements.py requirements.txt [requirements_other.txt]"
     )
     sys.exit(0)
 
@@ -17,8 +17,8 @@ for req_file in all_req_files:
         requirements.extend(f.readlines())
 
 
-def pip(req_files):
-    args = ["pip", "install"]
+def uv(req_files):
+    args = ["uv", "pip", "install"]
     for req_file in req_files:
         args.extend(["-r", req_file])
     p = subprocess.Popen(
@@ -43,4 +43,4 @@ try:
 
 except (DistributionNotFound, VersionConflict) as e:
     print(e.report())
-    pip(all_req_files)
+    uv(all_req_files)

--- a/kowalski/tools/tests.py
+++ b/kowalski/tools/tests.py
@@ -120,7 +120,7 @@ def test(use_docker=False):
                 t["container"],
                 "bash",
                 "-c",
-                " ".join(command),
+                "source env/bin/activate" + " ".join(command),
             ]
         try:
             subprocess.run(command, check=True)

--- a/kowalski/tools/tests.py
+++ b/kowalski/tools/tests.py
@@ -120,7 +120,8 @@ def test(use_docker=False):
                 t["container"],
                 "bash",
                 "-c",
-                "source env/bin/activate " + " ".join(command),
+                "VIRTUAL_ENV=/usr/local && source env/bin/activate "
+                + " ".join(command),
             ]
         try:
             subprocess.run(command, check=True)

--- a/kowalski/tools/tests.py
+++ b/kowalski/tools/tests.py
@@ -97,7 +97,7 @@ def test(use_docker=False):
                         "kowalski-ingester-1",
                         "bash",
                         "-c",
-                        "make stop_ingester",
+                        "VIRTUAL_ENV=/usr/local && source env/bin/activate && make stop_ingester",
                     ],
                     check=True,
                 )
@@ -120,7 +120,7 @@ def test(use_docker=False):
                 t["container"],
                 "bash",
                 "-c",
-                "VIRTUAL_ENV=/usr/local && source env/bin/activate "
+                "VIRTUAL_ENV=/usr/local && source env/bin/activate && "
                 + " ".join(command),
             ]
         try:

--- a/kowalski/tools/tests.py
+++ b/kowalski/tools/tests.py
@@ -120,7 +120,7 @@ def test(use_docker=False):
                 t["container"],
                 "bash",
                 "-c",
-                "source env/bin/activate" + " ".join(command),
+                "source env/bin/activate " + " ".join(command),
             ]
         try:
             subprocess.run(command, check=True)

--- a/kowalski/tools/tests.py
+++ b/kowalski/tools/tests.py
@@ -97,7 +97,7 @@ def test(use_docker=False):
                         "kowalski-ingester-1",
                         "bash",
                         "-c",
-                        "VIRTUAL_ENV=/usr/local && source env/bin/activate && make stop_ingester",
+                        "export VIRTUAL_ENV=/usr/local && source env/bin/activate && make stop_ingester",
                     ],
                     check=True,
                 )
@@ -120,7 +120,7 @@ def test(use_docker=False):
                 t["container"],
                 "bash",
                 "-c",
-                "VIRTUAL_ENV=/usr/local && source env/bin/activate && "
+                "export VIRTUAL_ENV=/usr/local && source env/bin/activate && "
                 + " ".join(command),
             ]
         try:


### PR DESCRIPTION
This PR migrates Kowalski from using `virtualenv` and `pip` to using the more elegant `uv` (does both virtual environment and super fast dependency installation). We use `uv` in the docker files, but also recommend using it in the documentation.