### PR TITLE
FilterTest handler unit test: fix

### DIFF
--- a/kowalski/tests/api/test_filter.py
+++ b/kowalski/tests/api/test_filter.py
@@ -581,7 +581,7 @@ async def test_filter_test_handler(aiohttp_client):
     assert "message" in result
 
     assert isinstance(result["data"], list)
-    assert len(result["data"]) == 1
+    assert len(result["data"]) == 22
 
     # now try it with a start and end date that don't match any alerts
     start_date = 2460229.9338542 - 5000


### PR DESCRIPTION
I fixed the handler ~2 months ago after noticing that editing the filter in place somehow resulting in subsequent API calls having that edited value in there instead of the original filter, even if it didn't change in the DB. Likely some caching from the mongodb driver in python, anyways it was fixed.

With that fix though, the results of calling that API in the unit test differs, and returns us more than 1 alert (as expected). This PR fixes the unit test to look for the right number of alerts passing that filter.