### PR TITLE
Decode avros in worker tasks, not main kafka thread

### DIFF
--- a/kowalski/alert_brokers/alert_broker.py
+++ b/kowalski/alert_brokers/alert_broker.py
@@ -220,34 +220,26 @@ class AlertConsumer:
             return decoded_msg
 
     @staticmethod
-    def process_alert(alert: Mapping, topic: str):
+    def process_alerts(avro_msg: bytes, topic: str):
         """Alert brokering task run by dask.distributed workers
 
-        :param alert: decoded alert from Kafka stream
+        :param avro_msg: avro message from Kafka stream
         :param topic: Kafka stream topic name for bookkeeping
         :return:
         """
         raise NotImplementedError("Must be implemented in subclass")
 
-    def submit_alert(self, record: Mapping):
-        # we look for objectId and objectid if missing,
-        # to support both ZTF and WNTR alert schemas
-        objectId = record.get("objectId", record.get("objectid", None))
-        if objectId is None:
-            log(
-                f"Failed to get objectId from record {record}, skipping alert submission"
-            )
-            return
+    def submit_alert(self, avro_msg: bytes):
         with timer(
-            f"Submitting alert {objectId} {record['candid']} for processing",
+            "Submitting alert for processing",
             self.verbose > 1,
         ):
             future = self.dask_client.submit(
-                self.process_alert, record, self.topic, pure=True
+                self.process_alerts, avro_msg, self.topic, pure=True
             )
             dask.distributed.fire_and_forget(future)
             future.release()
-            del future, record
+            del future, avro_msg  # clean up after thyself
         return
 
     def poll(self):
@@ -264,22 +256,7 @@ class AlertConsumer:
 
         elif msg is not None:
             try:
-                # decode avro packet
-                with timer("Decoding alert", self.verbose > 1):
-                    msg_decoded = self.decode_message(msg)
-
-                for record in msg_decoded:
-                    if (
-                        retry(self.mongo.db[self.collection_alerts].count_documents)(
-                            {"candid": record["candid"]}, limit=1
-                        )
-                        == 0
-                    ):
-
-                        self.submit_alert(record)
-
-                # clean up after thyself
-                del msg_decoded
+                self.submit_alert(msg)
 
             except Exception as e:
                 print("Error in poll!")

--- a/kowalski/alert_brokers/alert_broker_turbo.py
+++ b/kowalski/alert_brokers/alert_broker_turbo.py
@@ -14,7 +14,7 @@ from typing import Mapping, Sequence
 import dask.distributed
 from kowalski.alert_brokers.alert_broker import AlertConsumer, AlertWorker, EopError
 from bson.json_util import loads as bson_loads
-from kowalski.utils import init_db_sync, timer
+from kowalski.utils import init_db_sync, timer, retry
 from kowalski.config import load_config
 from kowalski.log import log
 
@@ -31,131 +31,151 @@ class TURBOAlertConsumer(AlertConsumer, ABC):
         super().__init__(topic, dask_client, **kwargs)
 
     @staticmethod
-    def process_alert(alert: Mapping, topic: str):
+    def process_alerts(avro_msg: bytes, topic: str, worker):
         """Alert brokering task run by dask.distributed workers
 
-        :param alert: decoded alert from Kafka stream
+        :param avro_msg: avro message from Kafka stream
         :param topic: Kafka stream topic name for bookkeeping
         :return:
         """
-        candid = alert["candid"]
-        object_id = alert["objectId"]
 
         # get worker running current task
         worker = dask.distributed.get_worker()
         alert_worker = worker.plugins["worker-init"].alert_worker
 
-        log(f"{topic} {object_id} {candid} {worker.address}")
+        with timer("Decoding alert", alert_worker.verbose > 1):
+            msg_decoded = alert_worker.decode_message(avro_msg)
 
-        # return if this alert packet has already been processed and ingested into collection_alerts:
-        if (
-            alert_worker.mongo.db[alert_worker.collection_alerts].count_documents(
-                {"candid": candid}, limit=1
-            )
-            == 1
-        ):
-            return
-
-        # candid not in db, ingest decoded avro packet into db
-        with timer(f"Mongification of {object_id} {candid}", alert_worker.verbose > 1):
-            alert, prv_candidates, _ = alert_worker.alert_mongify(alert)
-
-        with timer(f"Ingesting {object_id} {candid}", alert_worker.verbose > 1):
-            alert_worker.mongo.insert_one(
-                collection=alert_worker.collection_alerts, document=alert
-            )
-
-        # prv_candidates: pop nulls - save space
-        prv_candidates = [
-            {kk: vv for kk, vv in prv_candidate.items() if vv is not None}
-            for prv_candidate in prv_candidates
-        ]
-
-        alert_aux, xmatches, xmatches_ztf, passed_filters = None, None, None, None
-        # cross-match with external catalogs if objectId not in collection_alerts_aux:
-        if (
-            alert_worker.mongo.db[alert_worker.collection_alerts_aux].count_documents(
-                {"_id": object_id}, limit=1
-            )
-            == 0
-        ):
-            with timer(
-                f"Cross-match of {object_id} {candid}", alert_worker.verbose > 1
+        for alert in msg_decoded:
+            candid = alert["candid"]
+            object_id = alert["objectid"]
+            if (
+                retry(
+                    alert_worker.mongo.db[
+                        alert_worker.collection_alerts
+                    ].count_documents
+                )({"candid": candid}, limit=1)
+                == 1
             ):
-                xmatches = alert_worker.alert_filter__xmatch(alert)
+                # this alert has already been processed, skip it
+                log(f"Alert {object_id} {candid} already processed, skipping")
+                continue
 
-            # Crossmatch new alert with most recent ZTF_alerts and insert
+            log(f"turbo: {topic} {object_id} {candid} {worker.address}")
+
+            # candid not in db, ingest decoded avro packet into db
             with timer(
-                f"ZTF Cross-match of {object_id} {candid}", alert_worker.verbose > 1
+                f"Mongification of {object_id} {candid}", alert_worker.verbose > 1
             ):
-                xmatches = {
-                    **xmatches,
-                    **alert_worker.alert_filter__xmatch_ztf_alerts(alert),
+                alert, prv_candidates, _ = alert_worker.alert_mongify(alert)
+
+            with timer(f"Ingesting {object_id} {candid}", alert_worker.verbose > 1):
+                alert_worker.mongo.insert_one(
+                    collection=alert_worker.collection_alerts, document=alert
+                )
+
+            # prv_candidates: pop nulls - save space
+            prv_candidates = [
+                {kk: vv for kk, vv in prv_candidate.items() if vv is not None}
+                for prv_candidate in prv_candidates
+            ]
+
+            alert_aux, xmatches, xmatches_ztf, passed_filters = None, None, None, None
+            # cross-match with external catalogs if objectId not in collection_alerts_aux:
+            if (
+                alert_worker.mongo.db[
+                    alert_worker.collection_alerts_aux
+                ].count_documents({"_id": object_id}, limit=1)
+                == 0
+            ):
+                with timer(
+                    f"Cross-match of {object_id} {candid}", alert_worker.verbose > 1
+                ):
+                    xmatches = alert_worker.alert_filter__xmatch(alert)
+
+                # Crossmatch new alert with most recent ZTF_alerts and insert
+                with timer(
+                    f"ZTF Cross-match of {object_id} {candid}", alert_worker.verbose > 1
+                ):
+                    xmatches = {
+                        **xmatches,
+                        **alert_worker.alert_filter__xmatch_ztf_alerts(alert),
+                    }
+
+                alert_aux = {
+                    "_id": object_id,
+                    "cross_matches": xmatches,
+                    "prv_candidates": prv_candidates,
                 }
 
-            alert_aux = {
-                "_id": object_id,
-                "cross_matches": xmatches,
-                "prv_candidates": prv_candidates,
-            }
+                with timer(
+                    f"Aux ingesting {object_id} {candid}", alert_worker.verbose > 1
+                ):
+                    alert_worker.mongo.insert_one(
+                        collection=alert_worker.collection_alerts_aux,
+                        document=alert_aux,
+                    )
 
-            with timer(f"Aux ingesting {object_id} {candid}", alert_worker.verbose > 1):
-                alert_worker.mongo.insert_one(
-                    collection=alert_worker.collection_alerts_aux, document=alert_aux
+            else:
+                with timer(
+                    f"Aux updating of {object_id} {candid}", alert_worker.verbose > 1
+                ):
+                    alert_worker.mongo.db[
+                        alert_worker.collection_alerts_aux
+                    ].update_one(
+                        {"_id": object_id},
+                        {"$addToSet": {"prv_candidates": {"$each": prv_candidates}}},
+                        upsert=True,
+                    )
+
+                # Crossmatch exisiting alert with most recent record in ZTF_alerts and update aux
+                with timer(
+                    f"ZTF Cross-match of {object_id} {candid}", alert_worker.verbose > 1
+                ):
+                    xmatches_ztf = alert_worker.alert_filter__xmatch_ztf_alerts(alert)
+
+                with timer(
+                    f"Aux updating of {object_id} {candid}", alert_worker.verbose > 1
+                ):
+                    alert_worker.mongo.db[
+                        alert_worker.collection_alerts_aux
+                    ].update_one(
+                        {"_id": object_id},
+                        {"$set": {"ZTF_alerts": xmatches_ztf}},
+                        upsert=True,
+                    )
+
+            if config["misc"]["broker"]:
+                # execute user-defined alert filters
+                with timer(
+                    f"Filtering of {object_id} {candid}", alert_worker.verbose > 1
+                ):
+                    passed_filters = alert_worker.alert_filter__user_defined(
+                        alert_worker.filter_templates, alert
+                    )
+                if alert_worker.verbose > 1:
+                    log(
+                        f"{object_id} {candid} number of filters passed: {len(passed_filters)}"
+                    )
+
+                # post to SkyPortal
+                alert_worker.alert_sentinel_skyportal(
+                    alert, prv_candidates, passed_filters=passed_filters
                 )
 
-        else:
-            with timer(
-                f"Aux updating of {object_id} {candid}", alert_worker.verbose > 1
-            ):
-                alert_worker.mongo.db[alert_worker.collection_alerts_aux].update_one(
-                    {"_id": object_id},
-                    {"$addToSet": {"prv_candidates": {"$each": prv_candidates}}},
-                    upsert=True,
-                )
-
-            # Crossmatch exisiting alert with most recent record in ZTF_alerts and update aux
-            with timer(
-                f"ZTF Cross-match of {object_id} {candid}", alert_worker.verbose > 1
-            ):
-                xmatches_ztf = alert_worker.alert_filter__xmatch_ztf_alerts(alert)
-
-            with timer(
-                f"Aux updating of {object_id} {candid}", alert_worker.verbose > 1
-            ):
-                alert_worker.mongo.db[alert_worker.collection_alerts_aux].update_one(
-                    {"_id": object_id},
-                    {"$set": {"ZTF_alerts": xmatches_ztf}},
-                    upsert=True,
-                )
-
-        if config["misc"]["broker"]:
-            # execute user-defined alert filters
-            with timer(f"Filtering of {object_id} {candid}", alert_worker.verbose > 1):
-                passed_filters = alert_worker.alert_filter__user_defined(
-                    alert_worker.filter_templates, alert
-                )
-            if alert_worker.verbose > 1:
-                log(
-                    f"{object_id} {candid} number of filters passed: {len(passed_filters)}"
-                )
-
-            # post to SkyPortal
-            alert_worker.alert_sentinel_skyportal(
-                alert, prv_candidates, passed_filters=passed_filters
+            # clean up after thyself
+            del (
+                alert,
+                prv_candidates,
+                xmatches,
+                xmatches_ztf,
+                alert_aux,
+                passed_filters,
+                candid,
+                object_id,
             )
 
-        # clean up after thyself
-        del (
-            alert,
-            prv_candidates,
-            xmatches,
-            xmatches_ztf,
-            alert_aux,
-            passed_filters,
-            candid,
-            object_id,
-        )
+        return
 
 
 class TURBOAlertWorker(AlertWorker, ABC):

--- a/kowalski/alert_brokers/alert_broker_winter.py
+++ b/kowalski/alert_brokers/alert_broker_winter.py
@@ -14,7 +14,7 @@ from typing import Mapping, Sequence, Union
 import dask.distributed
 from kowalski.alert_brokers.alert_broker import AlertConsumer, AlertWorker, EopError
 from bson.json_util import loads as bson_loads
-from kowalski.utils import init_db_sync, timer
+from kowalski.utils import init_db_sync, timer, retry
 from kowalski.config import load_config
 from kowalski.log import log
 
@@ -47,146 +47,160 @@ class WNTRAlertConsumer(AlertConsumer, ABC):
         super().__init__(topic, dask_client, **kwargs)
 
     @staticmethod
-    def process_alert(alert: Mapping, topic: str):
-        """
-        Main function that runs on a single alert.
-            -Read top-level packet field
-            -Separate alert and prv_candidate in MongoDB prep
+    def process_alerts(avro_msg: bytes, topic: str, worker):
+        """Alert brokering task run by dask.distributed workers
 
-        :param alert: decoded alert from Kafka stream
+        :param avro_msg: avro message from Kafka stream
         :param topic: Kafka stream topic name for bookkeeping
         :return:
         """
-        candid = alert["candid"]
-        object_id = alert["objectid"]
 
         # get worker running current task
         worker = dask.distributed.get_worker()
         alert_worker = worker.plugins["worker-init"].alert_worker
 
-        log(f"winter: {topic} {object_id} {candid} {worker.address}")
+        with timer("Decoding alert", alert_worker.verbose > 1):
+            msg_decoded = alert_worker.decode_message(avro_msg)
 
-        # return if this alert packet has already been processed
-        # and ingested into collection_alerts:
-        if (
-            alert_worker.mongo.db[alert_worker.collection_alerts].count_documents(
-                {"candid": candid}, limit=1
-            )
-            == 1
-        ):
-            return
-
-        # candid not in db, ingest decoded avro packet into db
-        with timer(f"Mongification of {object_id} {candid}"):
-            alert, prv_candidates, _ = alert_worker.alert_mongify(alert)
-
-        # future: add ML model filtering here
-
-        with timer(f"Ingesting {object_id} {candid}", alert_worker.verbose > 1):
-            alert_worker.mongo.insert_one(
-                collection=alert_worker.collection_alerts, document=alert
-            )
-
-        # prv_candidates: pop nulls - save space
-        prv_candidates = [
-            {kk: vv for kk, vv in prv_candidate.items() if vv is not None}
-            for prv_candidate in prv_candidates
-        ]
-
-        alert_aux, xmatches, xmatches_ztf, passed_filters = None, None, None, None
-        # cross-match with external catalogs if objectId not in collection_alerts_aux:
-        if (
-            alert_worker.mongo.db[alert_worker.collection_alerts_aux].count_documents(
-                {"_id": object_id}, limit=1
-            )
-            == 0
-        ):
-            with timer(
-                f"Cross-match of {object_id} {candid}", alert_worker.verbose > 1
+        for alert in msg_decoded:
+            candid = alert["candid"]
+            object_id = alert["objectid"]
+            if (
+                retry(
+                    alert_worker.mongo.db[
+                        alert_worker.collection_alerts
+                    ].count_documents
+                )({"candid": candid}, limit=1)
+                == 1
             ):
-                xmatches = alert_worker.alert_filter__xmatch(alert)
+                # this alert has already been processed, skip it
+                log(f"Alert {object_id} {candid} already processed, skipping")
+                continue
 
-            # Crossmatch new alert with most recent ZTF_alerts and insert
-            with timer(
-                f"ZTF Cross-match of {object_id} {candid}", alert_worker.verbose > 1
+            log(f"winter: {topic} {object_id} {candid} {worker.address}")
+
+            # candid not in db, ingest decoded avro packet into db
+            with timer(f"Mongification of {object_id} {candid}"):
+                alert, prv_candidates, _ = alert_worker.alert_mongify(alert)
+
+            # future: add ML model filtering here
+
+            with timer(f"Ingesting {object_id} {candid}", alert_worker.verbose > 1):
+                alert_worker.mongo.insert_one(
+                    collection=alert_worker.collection_alerts, document=alert
+                )
+
+            # prv_candidates: pop nulls - save space
+            prv_candidates = [
+                {kk: vv for kk, vv in prv_candidate.items() if vv is not None}
+                for prv_candidate in prv_candidates
+            ]
+
+            alert_aux, xmatches, xmatches_ztf, passed_filters = None, None, None, None
+            # cross-match with external catalogs if objectId not in collection_alerts_aux:
+            if (
+                alert_worker.mongo.db[
+                    alert_worker.collection_alerts_aux
+                ].count_documents({"_id": object_id}, limit=1)
+                == 0
             ):
-                xmatches = {
-                    **xmatches,
-                    **alert_worker.alert_filter__xmatch_ztf_alerts(alert),
+                with timer(
+                    f"Cross-match of {object_id} {candid}", alert_worker.verbose > 1
+                ):
+                    xmatches = alert_worker.alert_filter__xmatch(alert)
+
+                # Crossmatch new alert with most recent ZTF_alerts and insert
+                with timer(
+                    f"ZTF Cross-match of {object_id} {candid}", alert_worker.verbose > 1
+                ):
+                    xmatches = {
+                        **xmatches,
+                        **alert_worker.alert_filter__xmatch_ztf_alerts(alert),
+                    }
+
+                alert_aux = {
+                    "_id": object_id,
+                    "cross_matches": xmatches,
+                    "prv_candidates": prv_candidates,
                 }
 
-            alert_aux = {
-                "_id": object_id,
-                "cross_matches": xmatches,
-                "prv_candidates": prv_candidates,
-            }
+                with timer(
+                    f"Aux ingesting {object_id} {candid}", alert_worker.verbose > 1
+                ):
+                    alert_worker.mongo.insert_one(
+                        collection=alert_worker.collection_alerts_aux,
+                        document=alert_aux,
+                    )
 
-            with timer(f"Aux ingesting {object_id} {candid}", alert_worker.verbose > 1):
-                alert_worker.mongo.insert_one(
-                    collection=alert_worker.collection_alerts_aux, document=alert_aux
+            else:
+                with timer(
+                    f"Aux updating of {object_id} {candid}", alert_worker.verbose > 1
+                ):
+                    alert_worker.mongo.db[
+                        alert_worker.collection_alerts_aux
+                    ].update_one(
+                        {"_id": object_id},
+                        {"$addToSet": {"prv_candidates": {"$each": prv_candidates}}},
+                        upsert=True,
+                    )
+
+                # Crossmatch exisiting alert with most recent record in ZTF_alerts and update aux
+                with timer(
+                    f"Exists in aux: ZTF Cross-match of {object_id} {candid}",
+                    alert_worker.verbose > 1,
+                ):
+                    xmatches_ztf = alert_worker.alert_filter__xmatch_ztf_alerts(alert)
+
+                with timer(
+                    f"Aux updating of {object_id} {candid}", alert_worker.verbose > 1
+                ):
+                    alert_worker.mongo.db[
+                        alert_worker.collection_alerts_aux
+                    ].update_one(
+                        {"_id": object_id},
+                        {"$set": {"cross_matches.ZTF_alerts": xmatches_ztf}},
+                        upsert=True,
+                    )
+
+            if config["misc"]["broker"]:
+                # winter has a different schema (fields have different names),
+                # so now that the alert packet has been ingested, we just add some aliases
+                # to avoid having to make exceptions all the time everywhere in the rest of the code
+                # not good memory-wise, but not worth adding if statements everywhere just for this...
+                alert["objectId"] = alert.get("objectid")
+                alert["cutoutScience"] = alert.get("cutout_science")
+                alert["cutoutTemplate"] = alert.get("cutout_template")
+                alert["cutoutDifference"] = alert.get("cutout_difference")
+                # execute user-defined alert filters
+                with timer(
+                    f"Filtering of {object_id} {candid}", alert_worker.verbose > 1
+                ):
+                    passed_filters = alert_worker.alert_filter__user_defined(
+                        alert_worker.filter_templates, alert
+                    )
+                if alert_worker.verbose > 1:
+                    log(
+                        f"{object_id} {candid} number of filters passed: {len(passed_filters)}"
+                    )
+
+                # post to SkyPortal
+                alert_worker.alert_sentinel_skyportal(
+                    alert, prv_candidates, passed_filters=passed_filters
                 )
 
-        else:
-            with timer(
-                f"Aux updating of {object_id} {candid}", alert_worker.verbose > 1
-            ):
-                alert_worker.mongo.db[alert_worker.collection_alerts_aux].update_one(
-                    {"_id": object_id},
-                    {"$addToSet": {"prv_candidates": {"$each": prv_candidates}}},
-                    upsert=True,
-                )
-
-            # Crossmatch exisiting alert with most recent record in ZTF_alerts and update aux
-            with timer(
-                f"Exists in aux: ZTF Cross-match of {object_id} {candid}",
-                alert_worker.verbose > 1,
-            ):
-                xmatches_ztf = alert_worker.alert_filter__xmatch_ztf_alerts(alert)
-
-            with timer(
-                f"Aux updating of {object_id} {candid}", alert_worker.verbose > 1
-            ):
-                alert_worker.mongo.db[alert_worker.collection_alerts_aux].update_one(
-                    {"_id": object_id},
-                    {"$set": {"cross_matches.ZTF_alerts": xmatches_ztf}},
-                    upsert=True,
-                )
-
-        if config["misc"]["broker"]:
-            # winter has a different schema (fields have different names),
-            # so now that the alert packet has been ingested, we just add some aliases
-            # to avoid having to make exceptions all the time everywhere in the rest of the code
-            # not good memory-wise, but not worth adding if statements everywhere just for this...
-            alert["objectId"] = alert.get("objectid")
-            alert["cutoutScience"] = alert.get("cutout_science")
-            alert["cutoutTemplate"] = alert.get("cutout_template")
-            alert["cutoutDifference"] = alert.get("cutout_difference")
-            # execute user-defined alert filters
-            with timer(f"Filtering of {object_id} {candid}", alert_worker.verbose > 1):
-                passed_filters = alert_worker.alert_filter__user_defined(
-                    alert_worker.filter_templates, alert
-                )
-            if alert_worker.verbose > 1:
-                log(
-                    f"{object_id} {candid} number of filters passed: {len(passed_filters)}"
-                )
-
-            # post to SkyPortal
-            alert_worker.alert_sentinel_skyportal(
-                alert, prv_candidates, passed_filters=passed_filters
+            # clean up after thyself
+            del (
+                alert,
+                prv_candidates,
+                xmatches,
+                xmatches_ztf,
+                alert_aux,
+                passed_filters,
+                candid,
+                object_id,
             )
 
-        # clean up after thyself
-        del (
-            alert,
-            prv_candidates,
-            xmatches,
-            xmatches_ztf,
-            alert_aux,
-            passed_filters,
-            candid,
-            object_id,
-        )
+        return
 
 
 class WNTRAlertWorker(AlertWorker, ABC):

--- a/kowalski/alert_brokers/alert_broker_ztf.py
+++ b/kowalski/alert_brokers/alert_broker_ztf.py
@@ -11,7 +11,7 @@ import numpy as np
 import pandas as pd
 from abc import ABC
 from copy import deepcopy
-from typing import Mapping, Sequence
+from typing import Sequence
 
 import dask.distributed
 from kowalski.alert_brokers.alert_broker import AlertConsumer, AlertWorker, EopError
@@ -33,194 +33,223 @@ class ZTFAlertConsumer(AlertConsumer, ABC):
         super().__init__(topic, dask_client, **kwargs)
 
     @staticmethod
-    def process_alert(alert: Mapping, topic: str):
+    def process_alerts(avro_msg: bytes, topic: str, worker):
         """Alert brokering task run by dask.distributed workers
 
-        :param alert: decoded alert from Kafka stream
+        :param avro_msg: avro message from Kafka stream
         :param topic: Kafka stream topic name for bookkeeping
         :return:
         """
-        candid = alert["candid"]
-        object_id = alert["objectId"]
 
         # get worker running current task
         worker = dask.distributed.get_worker()
         alert_worker: ZTFAlertWorker = worker.plugins["worker-init"].alert_worker
 
-        log(f"{topic} {object_id} {candid} {worker.address}")
+        with timer("Decoding alert", alert_worker.verbose > 1):
+            msg_decoded = alert_worker.decode_message(avro_msg)
 
-        # return if this alert packet has already been processed and ingested into collection_alerts:
-        if (
-            retry(
-                alert_worker.mongo.db[alert_worker.collection_alerts].count_documents
-            )({"candid": candid}, limit=1)
-            == 1
-        ):
-            return
-
-        # candid not in db, ingest decoded avro packet into db
-        with timer(f"Mongification of {object_id} {candid}", alert_worker.verbose > 1):
-            alert, prv_candidates, fp_hists = alert_worker.alert_mongify(alert)
-
-        # create alert history
-        all_prv_candidates = deepcopy(prv_candidates) + [deepcopy(alert["candidate"])]
-        with timer(
-            f"Gather all previous candidates for {object_id} {candid}",
-            alert_worker.verbose > 1,
-        ):
-            # get all prv_candidates for this objectId:
-            existing_aux = retry(
-                alert_worker.mongo.db[alert_worker.collection_alerts_aux].find_one
-            )({"_id": object_id}, {"prv_candidates": 1})
+        for alert in msg_decoded:
+            candid = alert["candid"]
+            object_id = alert["objectId"]
             if (
-                existing_aux is not None
-                and len(existing_aux.get("prv_candidates", [])) > 0
-            ):
-                all_prv_candidates += existing_aux["prv_candidates"]
-
-            # get all alerts for this objectId:
-            existing_alerts = list(
-                alert_worker.mongo.db[alert_worker.collection_alerts].find(
-                    {"objectId": object_id}, {"candidate": 1}
-                )
-            )
-            if len(existing_alerts) > 0:
-                all_prv_candidates += [
-                    existing_alert["candidate"] for existing_alert in existing_alerts
-                ]
-            del existing_aux, existing_alerts
-
-        # ML models:
-        with timer(f"MLing of {object_id} {candid}", alert_worker.verbose > 1):
-            scores = alert_worker.alert_filter__ml(alert, all_prv_candidates)
-            alert["classifications"] = scores
-
-        with timer(f"Ingesting {object_id} {candid}", alert_worker.verbose > 1):
-            retry(alert_worker.mongo.insert_one)(
-                collection=alert_worker.collection_alerts, document=alert
-            )
-
-        # prv_candidates: pop nulls - save space
-        prv_candidates = [
-            {kk: vv for kk, vv in prv_candidate.items() if vv is not None}
-            for prv_candidate in prv_candidates
-        ]
-
-        # fp_hists: pop nulls - save space
-        fp_hists = [
-            {kk: vv for kk, vv in fp_hist.items() if vv not in [None, -99999, -99999.0]}
-            for fp_hist in fp_hists
-        ]
-
-        # format fp_hists, add alert_mag, alert_ra, alert_dec
-        # and computing the FP's mag, magerr, snr, limmag3sig, limmag5sig
-        fp_hists = alert_worker.format_fp_hists(alert, fp_hists)
-
-        alert_aux, xmatches, passed_filters = None, None, None
-        # cross-match with external catalogs if objectId not in collection_alerts_aux:
-        if (
-            retry(
-                alert_worker.mongo.db[
-                    alert_worker.collection_alerts_aux
-                ].count_documents
-            )({"_id": object_id}, limit=1)
-            == 0
-        ):
-            with timer(
-                f"Cross-match of {object_id} {candid}", alert_worker.verbose > 1
-            ):
-                xmatches = alert_worker.alert_filter__xmatch(alert)
-
-            alert_aux = {
-                "_id": object_id,
-                "cross_matches": xmatches,
-                "prv_candidates": prv_candidates,
-            }
-
-            # only add the fp_hists if its a recent/new object, which we determine based on either:
-            # - ndethist <= 1, we never detected it before
-            # - we detected it before (maybe missed a few alerts), but the first detection was
-            #   less than 30 days ago, which is the maximum time window of the incoming data
-            #   which means that we still have a lightcurve that dates back to the first detection
-            if (
-                alert["candidate"]["ndethist"] <= 1
-                or (alert["candidate"]["jd"] - alert["candidate"].get("jdstarthist", 0))
-                < 30
-            ):
-                alert_aux["fp_hists"] = fp_hists
-            else:
-                # if we don't save it, empty the fp_hists array to not send to SkyPortal what is not saved here.
-                fp_hists = []
-
-            with timer(f"Aux ingesting {object_id} {candid}", alert_worker.verbose > 1):
-                retry(alert_worker.mongo.insert_one)(
-                    collection=alert_worker.collection_alerts_aux, document=alert_aux
-                )
-
-        else:
-            with timer(
-                f"Aux updating of {object_id} {candid}", alert_worker.verbose > 1
-            ):
-                # update prv_candidates
                 retry(
-                    alert_worker.mongo.db[alert_worker.collection_alerts_aux].update_one
-                )(
-                    {"_id": object_id},
-                    {"$addToSet": {"prv_candidates": {"$each": prv_candidates}}},
-                    upsert=True,
+                    alert_worker.mongo.db[
+                        alert_worker.collection_alerts
+                    ].count_documents
+                )({"candid": candid}, limit=1)
+                == 1
+            ):
+                # this alert has already been processed, skip it
+                log(f"Alert {object_id} {candid} already processed, skipping")
+                continue
+
+            log(f"ztf: {topic} {object_id} {candid} {worker.address}")
+
+            # candid not in db, ingest decoded avro packet into db
+            with timer(
+                f"Mongification of {object_id} {candid}", alert_worker.verbose > 1
+            ):
+                alert, prv_candidates, fp_hists = alert_worker.alert_mongify(alert)
+
+            # create alert history
+            all_prv_candidates = deepcopy(prv_candidates) + [
+                deepcopy(alert["candidate"])
+            ]
+            with timer(
+                f"Gather all previous candidates for {object_id} {candid}",
+                alert_worker.verbose > 1,
+            ):
+                # get all prv_candidates for this objectId:
+                existing_aux = retry(
+                    alert_worker.mongo.db[alert_worker.collection_alerts_aux].find_one
+                )({"_id": object_id}, {"prv_candidates": 1})
+                if (
+                    existing_aux is not None
+                    and len(existing_aux.get("prv_candidates", [])) > 0
+                ):
+                    all_prv_candidates += existing_aux["prv_candidates"]
+
+                # get all alerts for this objectId:
+                existing_alerts = list(
+                    alert_worker.mongo.db[alert_worker.collection_alerts].find(
+                        {"objectId": object_id}, {"candidate": 1}
+                    )
+                )
+                if len(existing_alerts) > 0:
+                    all_prv_candidates += [
+                        existing_alert["candidate"]
+                        for existing_alert in existing_alerts
+                    ]
+                del existing_aux, existing_alerts
+
+            # ML models:
+            with timer(f"MLing of {object_id} {candid}", alert_worker.verbose > 1):
+                scores = alert_worker.alert_filter__ml(alert, all_prv_candidates)
+                alert["classifications"] = scores
+
+            with timer(f"Ingesting {object_id} {candid}", alert_worker.verbose > 1):
+                retry(alert_worker.mongo.insert_one)(
+                    collection=alert_worker.collection_alerts, document=alert
                 )
 
-                # if there is no fp_hists for this object, we don't update anything
-                # the idea is that we start accumulating FP only for new objects, to avoid
-                # having some objects with incomplete FP history, which would be confusing for the filters
-                # either there is full FP, or there isn't any
-                # we also update the fp_hists array we have here with the updated 30-day window
+            # prv_candidates: pop nulls - save space
+            prv_candidates = [
+                {kk: vv for kk, vv in prv_candidate.items() if vv is not None}
+                for prv_candidate in prv_candidates
+            ]
+
+            # fp_hists: pop nulls - save space
+            fp_hists = [
+                {
+                    kk: vv
+                    for kk, vv in fp_hist.items()
+                    if vv not in [None, -99999, -99999.0]
+                }
+                for fp_hist in fp_hists
+            ]
+
+            # format fp_hists, add alert_mag, alert_ra, alert_dec
+            # and computing the FP's mag, magerr, snr, limmag3sig, limmag5sig
+            fp_hists = alert_worker.format_fp_hists(alert, fp_hists)
+
+            alert_aux, xmatches, passed_filters = None, None, None
+            # cross-match with external catalogs if objectId not in collection_alerts_aux:
+            if (
+                retry(
+                    alert_worker.mongo.db[
+                        alert_worker.collection_alerts_aux
+                    ].count_documents
+                )({"_id": object_id}, limit=1)
+                == 0
+            ):
+                with timer(
+                    f"Cross-match of {object_id} {candid}", alert_worker.verbose > 1
+                ):
+                    xmatches = alert_worker.alert_filter__xmatch(alert)
+
+                alert_aux = {
+                    "_id": object_id,
+                    "cross_matches": xmatches,
+                    "prv_candidates": prv_candidates,
+                }
+
+                # only add the fp_hists if its a recent/new object, which we determine based on either:
+                # - ndethist <= 1, we never detected it before
+                # - we detected it before (maybe missed a few alerts), but the first detection was
+                #   less than 30 days ago, which is the maximum time window of the incoming data
+                #   which means that we still have a lightcurve that dates back to the first detection
                 if (
+                    alert["candidate"]["ndethist"] <= 1
+                    or (
+                        alert["candidate"]["jd"]
+                        - alert["candidate"].get("jdstarthist", 0)
+                    )
+                    < 30
+                ):
+                    alert_aux["fp_hists"] = fp_hists
+                else:
+                    # if we don't save it, empty the fp_hists array to not send to SkyPortal what is not saved here.
+                    fp_hists = []
+
+                with timer(
+                    f"Aux ingesting {object_id} {candid}", alert_worker.verbose > 1
+                ):
+                    retry(alert_worker.mongo.insert_one)(
+                        collection=alert_worker.collection_alerts_aux,
+                        document=alert_aux,
+                    )
+
+            else:
+                with timer(
+                    f"Aux updating of {object_id} {candid}", alert_worker.verbose > 1
+                ):
+                    # update prv_candidates
                     retry(
                         alert_worker.mongo.db[
                             alert_worker.collection_alerts_aux
-                        ].count_documents
+                        ].update_one
                     )(
-                        {"_id": alert["objectId"], "fp_hists": {"$exists": True}},
-                        limit=1,
+                        {"_id": object_id},
+                        {"$addToSet": {"prv_candidates": {"$each": prv_candidates}}},
+                        upsert=True,
                     )
-                    == 1
-                ):
-                    fp_hists = alert_worker.update_fp_hists(alert, fp_hists)
-                else:
+
                     # if there is no fp_hists for this object, we don't update anything
-                    # and we empty the fp_hists array to not send to SkyPortal what is not saved here.
-                    fp_hists = []
+                    # the idea is that we start accumulating FP only for new objects, to avoid
+                    # having some objects with incomplete FP history, which would be confusing for the filters
+                    # either there is full FP, or there isn't any
+                    # we also update the fp_hists array we have here with the updated 30-day window
+                    if (
+                        retry(
+                            alert_worker.mongo.db[
+                                alert_worker.collection_alerts_aux
+                            ].count_documents
+                        )(
+                            {"_id": alert["objectId"], "fp_hists": {"$exists": True}},
+                            limit=1,
+                        )
+                        == 1
+                    ):
+                        fp_hists = alert_worker.update_fp_hists(alert, fp_hists)
+                    else:
+                        # if there is no fp_hists for this object, we don't update anything
+                        # and we empty the fp_hists array to not send to SkyPortal what is not saved here.
+                        fp_hists = []
 
-        if config["misc"]["broker"]:
-            # execute user-defined alert filters
-            with timer(f"Filtering of {object_id} {candid}", alert_worker.verbose > 1):
-                passed_filters = alert_worker.alert_filter__user_defined(
-                    alert_worker.filter_templates, alert
-                )
-            if alert_worker.verbose > 1:
-                log(
-                    f"{object_id} {candid} number of filters passed: {len(passed_filters)}"
+            if config["misc"]["broker"]:
+                # execute user-defined alert filters
+                with timer(
+                    f"Filtering of {object_id} {candid}", alert_worker.verbose > 1
+                ):
+                    passed_filters = alert_worker.alert_filter__user_defined(
+                        alert_worker.filter_templates, alert
+                    )
+                if alert_worker.verbose > 1:
+                    log(
+                        f"{object_id} {candid} number of filters passed: {len(passed_filters)}"
+                    )
+
+                # post to SkyPortal
+                alert_worker.alert_sentinel_skyportal(
+                    alert,
+                    prv_candidates,
+                    fp_hists=fp_hists,
+                    passed_filters=passed_filters,
                 )
 
-            # post to SkyPortal
-            alert_worker.alert_sentinel_skyportal(
-                alert, prv_candidates, fp_hists=fp_hists, passed_filters=passed_filters
+            # clean up after thyself
+            del (
+                alert,
+                prv_candidates,
+                fp_hists,
+                all_prv_candidates,
+                scores,
+                xmatches,
+                alert_aux,
+                passed_filters,
+                candid,
+                object_id,
             )
-
-        # clean up after thyself
-        del (
-            alert,
-            prv_candidates,
-            fp_hists,
-            all_prv_candidates,
-            scores,
-            xmatches,
-            alert_aux,
-            passed_filters,
-            candid,
-            object_id,
-        )
 
         return
 


### PR DESCRIPTION
Based on the benchmarking we did to compare boom to Kowalski, it's clear that Kowalski is limited by how we read from kafka before submitting alerts for processing. At the moment, in one thread we read from kafka + decode the message + check if alerts are already processed, all sequentially before we submit an alert for processing by one of the workers in the cluster. 

This means that we do a lot of work single threaded before submitting anything to the workers for processing, when that work could be done by the workers in order to parallelize it.