### PR TITLE
Bugfix: pin Paramiko to 3.5.1 (<4.0.0)

### DIFF
--- a/requirements/requirements_api.txt
+++ b/requirements/requirements_api.txt
@@ -19,6 +19,7 @@ pymongo==4.8.0
 PyYAML==6.0.2
 requests==2.32.3
 sshtunnel==0.4.0
+paramiko==3.5.1
 supervisor==4.2.5
 uvloop==0.21.0
 ligo.skymap==2.2.0


### PR DESCRIPTION
We pin paramiko to a version after 4.0.0 which removed support for DSA(DSSKey). `sshtunnel` isn't maintained and looks for DSSKey (so it throws an error with the new paramiko), and in general we may need that algorithm to connect to some old servers.